### PR TITLE
Making it very hard to commit and push env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ buck-out/
 
 # environment variables
 #
-.env
-.env.production
-.env.staging
-.env.development
+.env*
+env*
+!.env.example


### PR DESCRIPTION
- Added rules in gitignore to ensure any file starting with env or .env is not tracked and thereby not committed or pushed by mistake or intentionally
- .env.example is added as an exception to this rule so .env.example is tracked
- This makes it hard not impossible so absolute caution is still required when checking in code