### PR TITLE
UI issues fixed

### DIFF
--- a/src/pages/Accounts/QRModal.tsx
+++ b/src/pages/Accounts/QRModal.tsx
@@ -68,8 +68,8 @@ export default function QRModal(props) {
             {props.isOpenedFlag && openCameraFlag ? (
               <View
                 style={{
-                  width: wp('100%'),
-                  height: wp('100%'),
+                  width: wp('90%'),
+                  height: wp('90%'),
                   overflow: 'hidden',
                   borderRadius: 20,
                 }}
@@ -79,8 +79,8 @@ export default function QRModal(props) {
                     this.cameraRef = ref;
                   }}
                   style={{
-                    width: wp('100%'),
-                    height: wp('100%'),
+                    width: wp('90%'),
+                    height: wp('90%'),
                   }}
                   onBarCodeRead={barcodeRecognized}
                   captureAudio={false}
@@ -161,8 +161,8 @@ export default function QRModal(props) {
                 <ImageBackground
                   source={require('../../assets/images/icons/iPhone-QR.png')}
                   style={{
-                    width: wp('100%'),
-                    height: wp('100%'),
+                    width: wp('90%'),
+                    height: wp('90%'),
                     overflow: 'hidden',
                     borderRadius: 20,
                   }}

--- a/src/pages/Contacts/TrustedContactRequest.tsx
+++ b/src/pages/Contacts/TrustedContactRequest.tsx
@@ -129,6 +129,8 @@ export default function TrustedContactRequest(props) {
             placeholder={'Enter Phone Number'}
             onChangeText={(text) => {
               setPhoneNumber(text);
+              if (text.length === 10)
+                checkForValidation(text)
             }}
             style={{ flex: 1 }}
             onFocus={() => {

--- a/src/pages/ManageBackup/PersonalCopyHistory.tsx
+++ b/src/pages/ManageBackup/PersonalCopyHistory.tsx
@@ -219,13 +219,13 @@ const PersonalCopyHistory = (props) => {
       );
       if (!personalCopyDetails) {
         dispatch(generatePersonalCopy(selectedPersonalCopy));
-        saveInTransitHistory();
+        // saveInTransitHistory();
       } else {
         personalCopyDetails = JSON.parse(personalCopyDetails);
 
         if (!personalCopyDetails[selectedPersonalCopy.type]) {
           dispatch(generatePersonalCopy(selectedPersonalCopy));
-          saveInTransitHistory();
+          // saveInTransitHistory();
         } else setPersonalCopyDetails(personalCopyDetails);
       }
     })();
@@ -305,6 +305,7 @@ const PersonalCopyHistory = (props) => {
           (PersonalCopyShareBottomSheet as any).current.snapTo(0);
         }}
         onPressShare={() => {
+          saveInTransitHistory()
           (PersonalCopyShareBottomSheet as any).current.snapTo(0);
         }}
       />

--- a/src/pages/ManageBackup/PersonalCopyHistory.tsx
+++ b/src/pages/ManageBackup/PersonalCopyHistory.tsx
@@ -488,7 +488,7 @@ const PersonalCopyHistory = (props) => {
             setTimeout(() => {
               setQRModalHeader('Reshare Personal Copy');
             }, 2);
-            (QrBottomSheet.current as any).snapTo(1);
+            (PersonalCopyShareBottomSheet.current as any).snapTo(1);
           }}
           onPressContinue={() => {
             (PersonalCopyShareBottomSheet as any).current.snapTo(1);

--- a/src/pages/ManageBackup/TrustedContactHistory.tsx
+++ b/src/pages/ManageBackup/TrustedContactHistory.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
   AsyncStorage,
   Alert,
+  Keyboard,
 } from 'react-native';
 import Fonts from '../../common/Fonts';
 import BackupStyles from './Styles';
@@ -264,6 +265,7 @@ const TrustedContactHistory = (props) => {
           (trustedContactsBottomSheet as any).current.snapTo(0);
         }}
         onPressContinue={async (selectedContacts, index) => {
+          Keyboard.dismiss()
           const isTrustedC = await isTrustedContact(selectedContacts[0]);
           if (isTrustedC) {
             Toast('Trusted Contact already exists');

--- a/src/pages/Recovery/RestoreByCloudQrCodeContents.tsx
+++ b/src/pages/Recovery/RestoreByCloudQrCodeContents.tsx
@@ -244,7 +244,7 @@ export default function RestoreByCloudQrCodeContents(props) {
           flex: 1,
           justifyContent: 'center',
           alignItems: 'center',
-          backgroundColor: 'red',
+          // backgroundColor: 'red',
         }}
       >
         <QrCodeModalContents


### PR DESCRIPTION
- Removed red background on recovery QR scanner (https://github.com/bithyve/hexa/issues/753)
- Added margins to Personal Copy QR scanner (https://github.com/bithyve/hexa/issues/756)
- Dismiss keyboard when contact is selected (https://github.com/bithyve/hexa/issues/755)
- Added text length check on phone number when accepting trusted contact request (https://github.com/bithyve/hexa/issues/754)
- Personal copy reshare button opens correct modal now
Removed persistent "in-transit" note from personal copy history