### PR TITLE
Recovery using Keeper device button action

### DIFF
--- a/src/pages/Recovery/RestoreWalletBySecondaryDevice.tsx
+++ b/src/pages/Recovery/RestoreWalletBySecondaryDevice.tsx
@@ -185,6 +185,7 @@ export default function RestoreWalletBySecondaryDevice(props) {
                   dispatch(
                     downloadMShare(REQUEST_DETAILS.KEY, null, 'recovery'),
                   );
+                  props.navigation.goBack();
                 }}
                 disabled={!!META_SHARE}
                 style={{


### PR DESCRIPTION
- "yes, I have scanned" button on recovery using secondary device now takes the user back to the recovery home screen