### PR TITLE
Restrict Wallet name length to 10 characters.

### DIFF
--- a/src/pages/NewWalletName.tsx
+++ b/src/pages/NewWalletName.tsx
@@ -70,7 +70,7 @@ export default function NewWalletName(props) {
               keyboardType={
                 Platform.OS == 'ios' ? 'ascii-capable' : 'visible-password'
               }
-              maxLength={20}
+              maxLength={10}
               onChangeText={(text) => {
                 text = text.replace(/[^A-Za-z]/g, '');
                 setWalletName(text);


### PR DESCRIPTION
- Resolve wallet name wrap issue at Home Screen via restrict Wallet name length to 10 characters.