### PR TITLE
Remove unused `Services` interface

### DIFF
--- a/src/common/interfaces/Interfaces.ts
+++ b/src/common/interfaces/Interfaces.ts
@@ -8,14 +8,6 @@ import {
 } from '../../bitcoin/utilities/Interface';
 import TrustedContactsService from '../../bitcoin/services/TrustedContactsService';
 
-export interface Services {
-  REGULAR_ACCOUNT: RegularAccount;
-  TEST_ACCOUNT: TestAccount;
-  SECURE_ACCOUNT: SecureAccount;
-  S3_SERVICE: S3Service;
-  TRUSTED_CONTACTS: TrustedContactsService;
-}
-
 export interface DynamicNonPMDD {
   META_SHARES?: MetaShare[];
 }


### PR DESCRIPTION
This is a precursor for some [changes I think we need to make](https://bithyve-workspace.slack.com/archives/CEBLWDEKH/p1600715886206000) in order to better differentiate between "service types" and "account types". Seemed like some low-hanging fruit because it wasn't being used.