### PR TITLE
Add .vscode/settings.json to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ ios/Podfile.lock
 
 # VSCode
 .vscode/.react
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
-  "java.configuration.updateBuildConfiguration": "automatic",
-}


### PR DESCRIPTION
Given that https://github.com/microsoft/vscode/issues/2809 is still an issue with VSCode, I'd recommend not trying to share settings.json across different environments. Right now, it generally seems to be intended as a custom user settings file.