### PR TITLE
Refactor custom bottom tab styles.

### DIFF
--- a/src/components/home/custom-bottom-tabs.tsx
+++ b/src/components/home/custom-bottom-tabs.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native'
+import React, { useMemo } from 'react'
+import { View, Image, StyleSheet, TouchableOpacity, ImageSourcePropType } from 'react-native'
 import Colors from '../../common/Colors';
 import DeviceInfo from 'react-native-device-info';
 import Fonts from './../../common/Fonts';
@@ -22,6 +22,67 @@ export interface Props {
   selectedTab: BottomTab;
 }
 
+type TabItem = {
+  tab: BottomTab;
+  activeImageSource: ImageSourcePropType;
+  inactiveImageSource: ImageSourcePropType;
+};
+
+const tabItems: TabItem[] = [
+  {
+    tab: BottomTab.Transactions,
+    activeImageSource: require('../../assets/images/HomePageIcons/icon_transactions_active.png'),
+    inactiveImageSource: require('../../assets/images/HomePageIcons/icon_transactions.png'),
+  },
+  {
+    tab: BottomTab.Add,
+    activeImageSource: require('../../assets/images/HomePageIcons/icon_add_active.png'),
+    inactiveImageSource: require('../../assets/images/HomePageIcons/icon_add.png'),
+  },
+  {
+    tab: BottomTab.QR,
+    activeImageSource: require('../../assets/images/HomePageIcons/icon_qr_active.png'),
+    inactiveImageSource: require('../../assets/images/HomePageIcons/icon_qr.png'),
+  },
+  {
+    tab: BottomTab.More,
+    activeImageSource: require('../../assets/images/HomePageIcons/icon_more.png'),
+    inactiveImageSource: require('../../assets/images/HomePageIcons/icon_more.png'),
+  },
+];
+
+
+type TabViewProps = {
+  tabItem: TabItem;
+  isActive: boolean;
+  onPress: () => void;
+}
+
+const Tab: React.FC<TabViewProps> = ({
+  tabItem,
+  isActive,
+  onPress,
+}: TabViewProps) => {
+
+  const imageSource = useMemo(() => {
+    return isActive ? tabItem.activeImageSource : tabItem.inactiveImageSource;
+  }, [tabItem.activeImageSource, tabItem.inactiveImageSource, isActive]);
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={styles.tabBarTabView}
+    >
+      <View style={styles.tab}>
+        <Image
+          source={imageSource}
+          style={styles.tabBarImage}
+        />
+      </View>
+    </TouchableOpacity>
+  );
+}
+
 const CustomBottomTabs: React.FC<Props> = ({
   tabBarZIndex = 1,
   onSelect,
@@ -29,90 +90,16 @@ const CustomBottomTabs: React.FC<Props> = ({
 }: Props) => {
   return (
     <View style={{ ...styles.bottomTabBarContainer, zIndex: tabBarZIndex }}>
-      <TouchableOpacity
-        onPress={() => onSelect(BottomTab.Transactions)}
-        style={styles.tabBarTabView}
-      >
-        {selectedTab == BottomTab.Transactions ? (
-          <View style={styles.activeTabStyle}>
-            <Image
-              source={require('../../assets/images/HomePageIcons/icon_transactions_active.png')}
-              style={{ width: 25, height: 25, resizeMode: 'contain' }}
-            />
-            <Text style={styles.activeTabTextStyle}>transactions</Text>
-          </View>
-        ) : (
-            <View style={{ flexDirection: 'row' }}>
-              <Image
-                source={require('../../assets/images/HomePageIcons/icon_transactions.png')}
-                style={styles.tabBarImage}
-              />
-            </View>
-          )}
-      </TouchableOpacity>
-      <TouchableOpacity
-        onPress={() => onSelect(BottomTab.Add)}
-        style={styles.tabBarTabView}
-      >
-        {selectedTab === BottomTab.Add ? (
-          <View style={styles.activeTabStyle}>
-            <Image
-              source={require('../../assets/images/HomePageIcons/icon_add_active.png')}
-              style={styles.tabBarImage}
-            />
-            <Text style={styles.activeTabTextStyle}>add</Text>
-          </View>
-        ) : (
-            <View style={{ flexDirection: 'row' }}>
-              <Image
-                source={require('../../assets/images/HomePageIcons/icon_add.png')}
-                style={styles.tabBarImage}
-              />
-            </View>
-          )}
-      </TouchableOpacity>
-      <TouchableOpacity
-        onPress={() => onSelect(BottomTab.QR)}
-        style={styles.tabBarTabView}
-      >
-        {selectedTab === BottomTab.QR ? (
-          <View style={styles.activeTabStyle}>
-            <Image
-              source={require('../../assets/images/HomePageIcons/icon_qr_active.png')}
-              style={styles.tabBarImage}
-            />
-            <Text style={styles.activeTabTextStyle}>qr</Text>
-          </View>
-        ) : (
-            <View style={{ flexDirection: 'row' }}>
-              <Image
-                source={require('../../assets/images/HomePageIcons/icon_qr.png')}
-                style={styles.tabBarImage}
-              />
-            </View>
-          )}
-      </TouchableOpacity>
-      <TouchableOpacity
-        style={styles.tabBarTabView}
-        onPress={() => onSelect(BottomTab.More)}
-      >
-        {selectedTab === BottomTab.More ? (
-          <View style={styles.activeTabStyle}>
-            <Image
-              source={require('../../assets/images/HomePageIcons/icon_more.png')}
-              style={styles.tabBarImage}
-            />
-            <Text style={styles.activeTabTextStyle}>more</Text>
-          </View>
-        ) : (
-            <View style={{ flexDirection: 'row' }}>
-              <Image
-                source={require('../../assets/images/HomePageIcons/icon_more.png')}
-                style={styles.tabBarImage}
-              />
-            </View>
-          )}
-      </TouchableOpacity>
+      {tabItems.map((tabItem, index) => {
+        return (
+          <Tab
+            key={index}
+            tabItem={tabItem}
+            isActive={selectedTab == tabItem.tab}
+            onPress={() => onSelect(tabItem.tab)}
+          />
+        );
+      })}
     </View>
   )
 }
@@ -120,6 +107,7 @@ const CustomBottomTabs: React.FC<Props> = ({
 export const TAB_BAR_HEIGHT = hp('12%');
 
 const styles = StyleSheet.create({
+
   bottomTabBarContainer: {
     backgroundColor: Colors.white,
     justifyContent: 'space-evenly',
@@ -136,25 +124,15 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     paddingBottom: DeviceInfo.hasNotch() ? hp('4%') : 0,
   },
+
   tabBarTabView: {
     padding: wp('5%'),
   },
-  activeTabStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: Colors.backgroundColor,
+
+  tab: {
     padding: 7,
-    borderRadius: 7,
-    width: 120,
-    height: 40,
-    justifyContent: 'center',
   },
-  activeTabTextStyle: {
-    marginLeft: 8,
-    color: Colors.blue,
-    fontFamily: Fonts.FiraSansRegular,
-    fontSize: RFValue(12),
-  },
+
   tabBarImage: {
     width: 21,
     height: 21,


### PR DESCRIPTION
Connected to https://github.com/bithyve/hexa/issues/1880.

This removes the explicit title and enlarged background area for active bottom tabs
so that each tab is evenly spaced and only displays an icon.