### PR TITLE
Fix Home deeplinking navigation logic.

### DIFF
--- a/src/navigation/Navigator.ts
+++ b/src/navigation/Navigator.ts
@@ -75,7 +75,6 @@ import NewOwnQuestions from '../pages/NewOwnQuestions';
 import NewRecoveryOwnQuestions from '../pages/Recovery/NewRecoveryOwnQuestions';
 import AddNewAccount from '../pages/Accounts/AddNewAccount';
 import AddNewDonationAccount from '../pages/Accounts/AddNewDonationAccount';
-import AllTransactionsStack from './stacks/transactions/AllTransactionsStack';
 import HomeStack from './stacks/home/HomeStack';
 
 
@@ -124,7 +123,6 @@ const MODAL_ROUTES = [
   'RecoveryRequestOTP',
   'Confirmation',
   'Intermediate',
-  'AllTransactions',
 ];
 
 const HomeNavigator = createStackNavigator(
@@ -138,9 +136,6 @@ const HomeNavigator = createStackNavigator(
       navigationOptions: {
         gesturesEnabled: false,
       },
-    },
-    AllTransactions: {
-      screen: AllTransactionsStack,
     },
     Intermediate,
     Accounts,

--- a/src/navigation/stacks/home/HomeStack.tsx
+++ b/src/navigation/stacks/home/HomeStack.tsx
@@ -6,11 +6,19 @@ import HomeQRScannerScreen from '../../../pages/Home/HomeQRScannerScreen';
 import NavStyles from '../../../common/Styles/NavStyles';
 import SmallNavHeaderCloseButton from '../../../components/navigation/SmallNavHeaderCloseButton';
 import MoreOptionsStack from '../more-options/MoreOptionsStack';
+import AllTransactionsStack from '../transactions/AllTransactionsStack';
+
 
 const HomeStack = createStackNavigator(
   {
     HomeRoot: {
       screen: HomeScreen,
+      navigationOptions: {
+        header: null,
+      },
+    },
+    AllTransactions: {
+      screen: AllTransactionsStack,
       navigationOptions: {
         header: null,
       },

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -102,7 +102,7 @@ import BottomSheetHeader from '../Accounts/BottomSheetHeader';
 import BottomSheetHandle from '../../components/bottom-sheets/BottomSheetHandle';
 import { Button } from 'react-native-elements';
 
-export const BOTTOM_SHEET_OPENING_ON_LAUNCH_DELAY = 500; // milliseconds
+export const BOTTOM_SHEET_OPENING_ON_LAUNCH_DELAY = 800; // milliseconds
 
 export const isCompatible = async (method: string, version: string) => {
   if (!semver.valid(version)) {
@@ -753,7 +753,6 @@ class Home extends PureComponent<HomePropsTypes, HomeStateTypes> {
     }
 
     Linking.addEventListener('url', this.handleDeepLinkEvent);
-
     Linking.getInitialURL().then(this.handleDeepLinking);
 
     // call this once deeplink is detected aswell
@@ -992,6 +991,8 @@ class Home extends PureComponent<HomePropsTypes, HomeStateTypes> {
   }
 
   openBottomSheetOnLaunch(ref: React.RefObject<BottomSheet>) {
+    this.props.navigation.popToTop();
+
     this.openBottomSheetOnLaunchTimeout = setTimeout(() => {
       ref.current?.snapTo(1);
     }, BOTTOM_SHEET_OPENING_ON_LAUNCH_DELAY);


### PR DESCRIPTION
Connected to https://github.com/bithyve/hexa/issues/1895.

- Pop to Top of the Home stack when Home is deep-linked into.
- Move the `AllTransactionsStack` into the `HomeStack` to unify behavior with other nested routes.

[More context](https://bithyve-workspace.slack.com/archives/CEBLWDEKH/p1603901448170500)