### PR TITLE
Fix bug on `SendToContact` screen.

### DIFF
--- a/src/pages/Accounts/SendToContact.tsx
+++ b/src/pages/Accounts/SendToContact.tsx
@@ -1347,9 +1347,9 @@ class SendToContact extends Component<
                   }}
                 >
                   {(!isConfirmDisabled &&
-                    accountsState[serviceType].accountsState.transfer) ||
+                    accountsState[serviceType].loading.transfer) ||
                     (isConfirmDisabled &&
-                      accountsState[serviceType].accountsState.transfer) ? (
+                      accountsState[serviceType].loading.transfer) ? (
                       <ActivityIndicator size="small" />
                     ) : (
                       <Text style={styles.buttonText}>{'Confirm & Proceed'}</Text>


### PR DESCRIPTION
We were calling `accountsState` `loading` in a number of places and when I changed it to `accountsState`, I accidentally renamined another variable that should have `loading` `accountsState` 😆