### PR TITLE
Fix QR Code Scan Callback in RestoreByCloudQRCodeContents.

### DIFF
--- a/src/pages/Accounts/Index.tsx
+++ b/src/pages/Accounts/Index.tsx
@@ -1215,11 +1215,6 @@ class Accounts extends Component<AccountsPropsTypes, AccountsStateTypes> {
                                 this.setState({ transactionItem: item });
                               }, 10);
                             }
-                            // props.navigation.navigate('TransactionDetails', {
-                            //   item,
-                            //   serviceType,
-                            //   getServiceType: getServiceType,
-                            // })
                           }
                           style={styles.transactionModalElementView}
                         >

--- a/src/pages/Home/HomeQRScannerScreen.tsx
+++ b/src/pages/Home/HomeQRScannerScreen.tsx
@@ -30,7 +30,7 @@ const HomeQRScannerScreen: React.FC<Props> = ({
   function handleBarcodeRecognized({ data: dataString }: { data: string }) {
     const onCodeScanned = navigation.getParam('onCodeScanned');
     if (typeof onCodeScanned === 'function') {
-      let data = getFormattedStringFromQRString(dataString)
+      let data = getFormattedStringFromQRString(dataString);
       onCodeScanned(data);
     }
 

--- a/src/pages/Recovery/RestoreByCloudQRCodeContents.tsx
+++ b/src/pages/Recovery/RestoreByCloudQRCodeContents.tsx
@@ -20,6 +20,7 @@ import ModalHeader from '../../components/ModalHeader';
 import Toast from '../../components/Toast';
 import CoveredQRCodeScanner from '../../components/qr-code-scanning/CoveredQRCodeScanner';
 import NavStyles from '../../common/Styles/NavStyles';
+import getFormattedStringFromQRString from '../../utils/qr-codes/GetFormattedStringFromQRData';
 
 export default function RestoreByCloudQRCodeContents(props) {
   const [qrData, setQrData] = useState('');
@@ -36,7 +37,7 @@ export default function RestoreByCloudQRCodeContents(props) {
   );
   console.log('unableRecoverShareFromQR', unableRecoverShareFromQR);
 
-  const getQrCodeData = (qrData) => {
+  const handleQRDataScanned = (qrData) => {
     let tempArray = qrDataArray;
     let shareCode = qrData.substring(0, 2);
     if (shareCode !== 'e0' && shareCode !== 'c0') {
@@ -224,7 +225,9 @@ export default function RestoreByCloudQRCodeContents(props) {
             Scan a Bitcoin address or any Hexa QR
           </Text>
 
-          <CoveredQRCodeScanner onCodeScanned={getQrCodeData} />
+          <CoveredQRCodeScanner onCodeScanned={({ data: dataString }: { data: string }) => {
+            handleQRDataScanned(getFormattedStringFromQRString(dataString));
+          }} />
         </View>
 
         <View


### PR DESCRIPTION
Connected to https://github.com/bithyve/hexa/issues/1962.

I think the issue here is that the callback is expecting an already-formatted string
from the data string returned by `RNCamera`. (Based upon how it was previously being called: https://github.com/bithyve/hexa/commit/91ffdb232bfce1707f118732480c42efe55e131f#diff-bdba0ba515494b5d339652ac7d22147f3b73931251b4b4f124f0393e337aaa35L242)