### PR TITLE
Fix account balance unit formatting on Send screen.

### DIFF
--- a/src/common/constants/Bitcoin.ts
+++ b/src/common/constants/Bitcoin.ts
@@ -1,0 +1,1 @@
+export const SATOSHIS_IN_BTC = 100000000

--- a/src/common/data/enums/BitcoinUnit.ts
+++ b/src/common/data/enums/BitcoinUnit.ts
@@ -1,0 +1,19 @@
+enum BitcoinUnit {
+  SATS,
+  BTC,
+  TSATS,
+}
+
+
+export function displayNameForBitcoinUnit(unit: BitcoinUnit): string {
+  switch (unit) {
+    case BitcoinUnit.SATS:
+      return "Sats";
+    case BitcoinUnit.BTC:
+      return "BTC";
+    case BitcoinUnit.TSATS:
+      return "T-Sats";
+  }
+}
+
+export default BitcoinUnit;

--- a/src/common/data/enums/UnitAliases.ts
+++ b/src/common/data/enums/UnitAliases.ts
@@ -1,0 +1,2 @@
+export type Satoshis = number;
+export type Milliseconds = number;

--- a/src/components/MaterialCurrencyCodeIcon.tsx
+++ b/src/components/MaterialCurrencyCodeIcon.tsx
@@ -17,15 +17,18 @@ export interface Props {
   iconName: string;
   color: string;
   size: number;
+  style?: Record<string, unknown>;
 }
 
 const MaterialCurrencyCodeIcon: React.FC<Props> = ({
   iconName,
   color,
   size,
+  style = {},
 }: Props) => {
   return (
     <MaterialCommunityIcons
+      style={style}
       name={iconName}
       color={color}
       size={size}

--- a/src/components/accounts/AccountBalanceDisplay.tsx
+++ b/src/components/accounts/AccountBalanceDisplay.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, Image, ImageSourcePropType } from 'react-native';
+import { RFValue } from 'react-native-responsive-fontsize';
+import Colors from '../../common/Colors';
+import Fonts from '../../common/Fonts';
+import CurrencyKind from '../../common/data/enums/CurrencyKind';
+import useCurrencyCode from '../../utils/hooks/state-selectors/UseCurrencyCode';
+import useCurrencyKind from '../../utils/hooks/state-selectors/UseCurrencyKind';
+import MaterialCurrencyCodeIcon, { materialIconCurrencyCodes } from '../MaterialCurrencyCodeIcon';
+import { getCurrencyImageByRegion } from '../../common/CommonFunctions';
+import useFormattedAmountText from '../../utils/hooks/formatting/UseFormattedAmountText';
+import useFormattedUnitText from '../../utils/hooks/formatting/UseFormattedUnitText';
+import { Satoshis } from '../../common/data/enums/UnitAliases';
+
+export type Props = {
+  balance: Satoshis;
+  color?: string;
+  iconSpacing?: number;
+  containerStyle?: Record<string, unknown>;
+  currencyImageSource?: ImageSourcePropType;
+  currencyImageStyle?: Record<string, unknown>;
+  amountTextStyle?: Record<string, unknown>;
+  unitTextStyle?: Record<string, unknown>;
+};
+
+
+const AccountBalanceDisplay: React.FC<Props> = ({
+  balance,
+  iconSpacing = 0,
+  color = Colors.currencyGray,
+  containerStyle = {},
+  currencyImageSource,
+  currencyImageStyle = {},
+  amountTextStyle = {},
+  unitTextStyle = {},
+}: Props) => {
+  const currencyKind = useCurrencyKind();
+  const fiatCurrencyCode = useCurrencyCode();
+
+  const prefersBitcoin: boolean = useMemo(() => {
+    return currencyKind === CurrencyKind.BITCOIN;
+  }, [currencyKind]);
+
+  const formattedBalanceText = useFormattedAmountText(balance);
+  const formattedUnitText = useFormattedUnitText(balance);
+
+  const BalanceCurrencyIcon = () => {
+    const style = {
+      ...styles.currencyImage,
+      ...currencyImageStyle,
+    };
+
+    if (currencyImageSource) {
+      return <Image
+        style={style}
+        source={currencyImageSource}
+      />;
+    } else if (prefersBitcoin) {
+      return <Image
+        style={style}
+        source={require('../../assets/images/currencySymbols/icon_bitcoin_gray.png')}
+      />;
+    } else if (materialIconCurrencyCodes.includes(fiatCurrencyCode)) {
+      return <MaterialCurrencyCodeIcon
+        iconName={fiatCurrencyCode}
+        color={color}
+        size={styles.currencyImage.width}
+        style={style}
+      />;
+    } else {
+      return <Image
+        style={style}
+        source={
+          getCurrencyImageByRegion(
+            fiatCurrencyCode,
+            'gray'
+          )
+        }
+      />;
+    }
+  };
+
+  return (
+    <View style={{ ...styles.rootContainer, ...containerStyle }}>
+      <View style={{ marginRight: iconSpacing }}>
+        <BalanceCurrencyIcon />
+      </View>
+
+      <Text style={{ ...styles.amountText, ...amountTextStyle, color }}>
+        {formattedBalanceText}
+      </Text>
+
+      <Text style={{ ...styles.unitText, ...unitTextStyle, color }}>
+        {formattedUnitText}
+      </Text>
+    </View>
+  );
+};
+
+
+const styles = StyleSheet.create({
+  rootContainer: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+  },
+
+  currencyImage: {
+    width: 14,
+    height: 14,
+    resizeMode: 'contain',
+  },
+
+  amountText: {
+    fontFamily: Fonts.OpenSans,
+    fontSize: RFValue(17),
+    marginRight: 3,
+    lineHeight: RFValue(17),
+  },
+
+  unitText: {
+    fontFamily: Fonts.FiraSansRegular,
+    fontSize: RFValue(11),
+    lineHeight: RFValue(17),
+  },
+});
+
+export default AccountBalanceDisplay;

--- a/src/pages/Accounts/AccountsListSend.tsx
+++ b/src/pages/Accounts/AccountsListSend.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import Colors from '../../common/Colors';
 import { RFValue } from 'react-native-responsive-fontsize';
@@ -6,7 +6,6 @@ import Fonts from './../../common/Fonts';
 import {
   widthPercentageToDP as wp,
 } from 'react-native-responsive-screen';
-import { UsNumberFormat } from '../../common/utilities';
 import CardView from 'react-native-cardview';
 import Entypo from 'react-native-vector-icons/Entypo';
 import {
@@ -14,6 +13,7 @@ import {
   SECURE_ACCOUNT,
 } from '../../common/constants/serviceTypes';
 import config from '../../bitcoin/HexaConfig';
+import AccountBalanceDisplay from '../../components/accounts/AccountBalanceDisplay';
 
 const AccountsListSend = ({
   balances,
@@ -22,6 +22,31 @@ const AccountsListSend = ({
   checkedItem,
   fromAddNewAccount
 }) => {
+
+  const balance = useMemo(() => {
+    if (accounts.id === REGULAR_ACCOUNT) {
+      balances.regularBalance;
+    } else if (accounts.id === SECURE_ACCOUNT) {
+      return balances.secureBalance;
+    } else if (
+      config.EJECTED_ACCOUNTS.includes(accounts.id) &&
+      balances.additionalBalances
+    ) {
+      return balances.additionalBalances[
+        accounts.type + accounts.id + accounts.account_number
+      ];
+    } else {
+      return 0;
+    }
+  }, [accounts]);
+
+  const balanceTextStyle = useMemo(() => {
+    return {
+      ...styles.accountBalance,
+      color: checkedItem ? Colors.white : Colors.borderColor,
+    };
+  }, [accounts]);
+
   return (
     <TouchableOpacity
       style={styles.accountView}
@@ -48,26 +73,16 @@ const AccountsListSend = ({
           >
             {accounts.account_name}
           </Text>
-          {!fromAddNewAccount ? <Text
-            style={{
-              ...styles.accountBalance,
-              color: checkedItem ? Colors.white : Colors.borderColor,
-            }}
-          >
-            {accounts.id === REGULAR_ACCOUNT
-              ? '$' + UsNumberFormat(balances.regularBalance)
-              : accounts.id === SECURE_ACCOUNT
-              ? '$' + UsNumberFormat(balances.secureBalance)
-              : config.EJECTED_ACCOUNTS.includes(accounts.id) &&
-                balances.additionalBalances
-              ? '$' +
-                UsNumberFormat(
-                  balances.additionalBalances[
-                    accounts.type + accounts.id + accounts.account_number
-                  ],
-                )
-              : 0}
-          </Text> : null}
+
+          {!fromAddNewAccount && (
+            <AccountBalanceDisplay
+              balance={balance}
+              currencyImageStyle={balanceTextStyle}
+              amountTextStyle={balanceTextStyle}
+              unitTextStyle={balanceTextStyle}
+            />
+          )}
+
           <View style={{ marginTop: wp('5%'), marginBottom: 7 }}>
             <TouchableOpacity
               onPress={() => onSelectContact(accounts)}

--- a/src/utils/hooks/formatting/UseFormattedAmountText.ts
+++ b/src/utils/hooks/formatting/UseFormattedAmountText.ts
@@ -1,0 +1,28 @@
+import { SATOSHIS_IN_BTC } from '../../../common/constants/Bitcoin';
+import CurrencyKind from '../../../common/data/enums/CurrencyKind';
+import { UsNumberFormat } from '../../../common/utilities';
+import useCurrencyCode from '../state-selectors/UseCurrencyCode';
+import useCurrencyKind from '../state-selectors/UseCurrencyKind';
+import useExchangeRates from '../state-selectors/UseExchangeRates';
+
+export default function useFormattedAmountText(
+  balance: number,
+): string {
+  const currencyKind = useCurrencyKind();
+  const fiatCurrencyCode = useCurrencyCode();
+  const exchangeRates = useExchangeRates();
+
+  if (currencyKind === CurrencyKind.BITCOIN) {
+    return UsNumberFormat(balance);
+  } else if (
+    exchangeRates !== undefined &&
+    exchangeRates[fiatCurrencyCode] !== undefined &&
+    exchangeRates[fiatCurrencyCode].last !== undefined
+  ) {
+    return (
+      (balance / SATOSHIS_IN_BTC) * exchangeRates[fiatCurrencyCode].last
+    ).toFixed(2);
+  } else {
+    return `${balance}`;
+  }
+}

--- a/src/utils/hooks/formatting/UseFormattedUnitText.ts
+++ b/src/utils/hooks/formatting/UseFormattedUnitText.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import BitcoinUnit, { displayNameForBitcoinUnit } from "../../../common/data/enums/BitcoinUnit";
+import CurrencyKind from "../../../common/data/enums/CurrencyKind";
+import useCurrencyCode from "../state-selectors/UseCurrencyCode";
+import useCurrencyKind from "../state-selectors/UseCurrencyKind";
+
+
+export default function useFormattedUnitText(
+  bitcoinUnit: BitcoinUnit,
+): string {
+  const currencyKind = useCurrencyKind();
+  const fiatCurrencyCode = useCurrencyCode();
+
+  const prefersBitcoin: boolean = useMemo(() => {
+    return currencyKind === CurrencyKind.BITCOIN;
+  }, [currencyKind]);
+
+  if (prefersBitcoin) {
+    return displayNameForBitcoinUnit(bitcoinUnit);
+  } else {
+    return fiatCurrencyCode.toLocaleLowerCase();
+  }
+}

--- a/src/utils/hooks/state-selectors/UseExchangeRates.ts
+++ b/src/utils/hooks/state-selectors/UseExchangeRates.ts
@@ -1,0 +1,5 @@
+import { useSelector } from 'react-redux';
+
+const useExchangeRates = () => useSelector(state => state.accounts.exchangeRates);
+
+export default useExchangeRates;


### PR DESCRIPTION
This leverages some of the utilities built out on the `feature/account-management` branch (see discussion [here](https://bithyve-workspace.slack.com/archives/CEBLWDEKH/p1604589388094300?thread_ts=1604545425.082500&cid=CEBLWDEKH)) to help with formatting balances and doing so in a way that's in sync with the user's current currency preferences.

Connected to https://github.com/bithyve/hexa/issues/1921.