### PR TITLE
Non-static ids: wrapper map err fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "underscore": "^1.10.2",
     "url": "^0.10.3",
     "util": "^0.10.4",
+    "uuid": "^8.3.1",
     "vm-browserify": "0.0.4"
   },
   "devDependencies": {

--- a/src/bitcoin/utilities/accounts/Bitcoin.ts
+++ b/src/bitcoin/utilities/accounts/Bitcoin.ts
@@ -11,6 +11,7 @@ import {
   SUB_PRIMARY_ACCOUNT,
   TRUSTED_CONTACTS,
 } from '../../../common/constants/serviceTypes';
+import { v4 as uuidv4 } from 'uuid';
 
 const { API_URLS, REQUEST_TIMEOUT } = config;
 const { TESTNET, MAINNET } = API_URLS;
@@ -120,8 +121,9 @@ export default class Bitcoin {
   }> => {
     let res: AxiosResponse;
     try {
+      const requestId = uuidv4();
       const accountToAddressMapping = {
-        ['mono-id']: {
+        [requestId]: {
           External: externalAddresses,
           Internal: internalAddresses,
           Owned: ownedAddresses,
@@ -141,12 +143,12 @@ export default class Bitcoin {
       }
 
       const accountToResponseMapping = res.data;
-      const { Utxos, Txs } = accountToResponseMapping['mono-id'];
+
+      const { Utxos, Txs } = accountToResponseMapping[requestId];
       let balances = {
         balance: 0,
         unconfirmedBalance: 0,
       };
-
       const UTXOs = [];
       if (Utxos)
         for (const addressSpecificUTXOs of Utxos) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9606,7 +9606,7 @@ uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==


### PR DESCRIPTION
Mitigates the possibility of following err on the wrapper while synching bal/tx/utxos via the nutxo ep.

```
2020/12/01 06:54:49 socat[9051] E write(6, 0x9b1da0, 24): Broken pipe
fatal error: concurrent map writes
fatal error: concurrent map writes
```