### PR TITLE
Add pbxproj file to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
+ios/HEXA.xcodeproj/project.pbxproj
+
 
 # Android/IntelliJ
 #


### PR DESCRIPTION
Given that we've decided to avoid committing our local changes to this file,
and pulling down the latest file from `development` instead if there are any
important updates, I think it would be useful to also add it to the .gitignore.

If someone _does_ want to check in changes to this file fromm a local branch,
they can utilize `git add -f <filename>` to override the .gitignore setting.