### PR TITLE
Tweak SubAccount constructors.

### DIFF
--- a/src/common/data/models/SubAccountInfo/DonationSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/DonationSubAccountInfo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidV4 } from 'uuid';
 import SubAccountKind from '../../enums/SubAccountKind';
 import {
   DonationSubAccountDescribing,
@@ -49,9 +48,9 @@ export default class DonationSubAccountInfo
   utxoCompatibilityGroup: UTXOCompatibilityGroup;
 
   constructor({
-    id = uuidV4(),
+    id,
     accountShellID = null,
-    instanceNumber = null,
+    instanceNumber,
     defaultTitle = 'Donation Account',
     balances = { confirmed: 0, unconfirmed: 0 },
     customDisplayName = null,

--- a/src/common/data/models/SubAccountInfo/ExternalServiceSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/ExternalServiceSubAccountInfo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidV4 } from 'uuid';
 import AccountVisibility from '../../enums/AccountVisibility';
 import ServiceAccountKind from '../../enums/ServiceAccountKind';
 import SubAccountKind from '../../enums/SubAccountKind';
@@ -44,9 +43,9 @@ export default class ExternalServiceSubAccountInfo
   utxoCompatibilityGroup: UTXOCompatibilityGroup;
 
   constructor({
-    id = uuidV4(),
+    id,
     accountShellID = null,
-    instanceNumber = null,
+    instanceNumber,
     defaultTitle,
     defaultDescription,
     serviceAccountKind,

--- a/src/common/data/models/SubAccountInfo/HexaSubAccounts/CheckingSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/HexaSubAccounts/CheckingSubAccountInfo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidV4 } from 'uuid';
 import {
   Balances,
   TransactionDetails,
@@ -38,9 +37,9 @@ export default class CheckingSubAccountInfo
     UTXOCompatibilityGroup.SINGLE_SIG_PUBLIC;
 
   constructor({
-    id = uuidV4(),
+    id,
     accountShellID = null,
-    instanceNumber = null,
+    instanceNumber,
     defaultTitle = 'Checking Account',
     balances = { confirmed: 0, unconfirmed: 0 },
     customDisplayName = null,

--- a/src/common/data/models/SubAccountInfo/HexaSubAccounts/SavingsSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/HexaSubAccounts/SavingsSubAccountInfo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidV4 } from 'uuid';
 import {
   Balances,
   TransactionDetails,
@@ -38,9 +37,9 @@ export default class SavingsSubAccountInfo implements HexaSubAccountDescribing {
     UTXOCompatibilityGroup.MULTI_SIG_PUBLIC;
 
   constructor({
-    id = uuidV4(),
+    id,
     accountShellID = null,
-    instanceNumber = null,
+    instanceNumber,
     defaultTitle = 'Savings Account',
     balances = { confirmed: 0, unconfirmed: 0 },
     customDisplayName = null,

--- a/src/common/data/models/SubAccountInfo/HexaSubAccounts/TestSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/HexaSubAccounts/TestSubAccountInfo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidV4 } from 'uuid';
 import {
   Balances,
   TransactionDetails,
@@ -38,9 +37,9 @@ export default class TestSubAccountInfo implements HexaSubAccountDescribing {
     UTXOCompatibilityGroup.TESTNET;
 
   constructor({
-    id = uuidV4(),
+    id,
     accountShellID = null,
-    instanceNumber = null,
+    instanceNumber,
     defaultTitle = 'Test Account',
     balances = { confirmed: 0, unconfirmed: 0 },
     customDisplayName = null,

--- a/src/common/data/models/SubAccountInfo/HexaSubAccounts/TrustedContactsSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/HexaSubAccounts/TrustedContactsSubAccountInfo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidV4 } from 'uuid';
 import AccountVisibility from '../../../enums/AccountVisibility';
 import SubAccountKind from '../../../enums/SubAccountKind';
 import UTXOCompatibilityGroup from '../../../enums/UTXOCompatibilityGroup';
@@ -40,9 +39,9 @@ export default class TrustedContactsSubAccountInfo
   utxoCompatibilityGroup: UTXOCompatibilityGroup;
 
   constructor({
-    id = uuidV4(),
+    id,
     accountShellID = null,
-    instanceNumber = null,
+    instanceNumber,
     defaultTitle = 'Trusted Contacts',
     balances = { confirmed: 0, unconfirmed: 0 },
     customDisplayName = null,

--- a/src/common/data/models/SubAccountInfo/ImportedWalletSubAccounts/FullyImportedWalletSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/ImportedWalletSubAccounts/FullyImportedWalletSubAccountInfo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidV4 } from 'uuid';
 import {
   Balances,
   TransactionDetails,
@@ -40,9 +39,9 @@ export default class FullyImportedWalletSubAccountInfo
     UTXOCompatibilityGroup.SINGLE_SIG_PUBLIC;
 
   constructor({
-    id = uuidV4(),
+    id,
     accountShellID = null,
-    instanceNumber = null,
+    instanceNumber,
     defaultTitle = 'Full Import',
     balances = { confirmed: 0, unconfirmed: 0 },
     customDisplayName = null,

--- a/src/common/data/models/SubAccountInfo/ImportedWalletSubAccounts/WatchOnlyImportedWalletSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/ImportedWalletSubAccounts/WatchOnlyImportedWalletSubAccountInfo.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidV4 } from 'uuid';
 import {
   Balances,
   TransactionDetails,
@@ -40,9 +39,9 @@ export default class WatchOnlyImportedWalletSubAccountInfo
     UTXOCompatibilityGroup.SINGLE_SIG_PUBLIC;
 
   constructor({
-    id = uuidV4(),
+    id,
     accountShellID = null,
-    instanceNumber = null,
+    instanceNumber,
     defaultTitle = 'Watch-Only',
     balances = { confirmed: 0, unconfirmed: 0 },
     customDisplayName = null,

--- a/src/common/data/models/SubAccountInfo/Interfaces.ts
+++ b/src/common/data/models/SubAccountInfo/Interfaces.ts
@@ -82,7 +82,7 @@ export interface ImportedWalletSubAccountDescribing
 export type SubAccountDescribingConstructorProps = {
   id?: string;
   accountShellID?: string | null;
-  instanceNumber?: number;
+  instanceNumber: number;
   defaultTitle?: string;
   customDisplayName?: string | null;
   customDescription?: string | null;


### PR DESCRIPTION
- require an instance number
- stop using uuid for the `id`