### PR TITLE
Lookup avatar images for subaccounts at run-time.

### DIFF
--- a/src/common/data/models/SubAccountInfo/DonationSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/DonationSubAccountInfo.ts
@@ -38,8 +38,6 @@ export default class DonationSubAccountInfo
   doneeName: string;
   causeName: string;
 
-  avatarImageSource = require('../../../../assets/images/icons/icon_donation_hexa.png');
-
   transactions: TransactionDetails[];
 
   /**

--- a/src/common/data/models/SubAccountInfo/ExternalServiceSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/ExternalServiceSubAccountInfo.ts
@@ -38,8 +38,6 @@ export default class ExternalServiceSubAccountInfo
   customDisplayName: string | null;
   customDescription: string | null;
 
-  avatarImageSource: ImageSourcePropType;
-
   transactions: TransactionDetails[];
   utxoCompatibilityGroup: UTXOCompatibilityGroup;
 
@@ -71,20 +69,5 @@ export default class ExternalServiceSubAccountInfo
     this.visibility = visibility;
     this.transactions = transactions;
     this.utxoCompatibilityGroup = utxoCompatibilityGroup;
-
-    this.avatarImageSource = getAvatarImageSource(serviceAccountKind);
-  }
-}
-
-function getAvatarImageSource(
-  serviceAccountKind: ServiceAccountKind,
-): ImageSourcePropType {
-  switch (serviceAccountKind) {
-    case ServiceAccountKind.FAST_BITCOINS:
-      return require('../../../../assets/images/icons/icon_fastbitcoins_hex_dark.png');
-    case ServiceAccountKind.SWAN:
-      return require('../../../../assets/images/icons/icon_swan.png');
-    default:
-      return require('../../../../assets/images/icons/icon_hexa.png');
   }
 }

--- a/src/common/data/models/SubAccountInfo/HexaSubAccounts/CheckingSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/HexaSubAccounts/CheckingSubAccountInfo.ts
@@ -31,8 +31,6 @@ export default class CheckingSubAccountInfo
   customDisplayName: string | null;
   customDescription: string | null;
 
-  avatarImageSource = require('../../../../../assets/images/icons/icon_regular.png');
-
   transactions: TransactionDetails[];
   utxoCompatibilityGroup: UTXOCompatibilityGroup =
     UTXOCompatibilityGroup.SINGLE_SIG_PUBLIC;

--- a/src/common/data/models/SubAccountInfo/HexaSubAccounts/SavingsSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/HexaSubAccounts/SavingsSubAccountInfo.ts
@@ -31,8 +31,6 @@ export default class SavingsSubAccountInfo implements HexaSubAccountDescribing {
   customDisplayName: string | null;
   customDescription: string | null;
 
-  avatarImageSource = require('../../../../../assets/images/icons/icon_secureaccount.png');
-
   transactions: TransactionDetails[];
   utxoCompatibilityGroup: UTXOCompatibilityGroup =
     UTXOCompatibilityGroup.MULTI_SIG_PUBLIC;

--- a/src/common/data/models/SubAccountInfo/HexaSubAccounts/TestSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/HexaSubAccounts/TestSubAccountInfo.ts
@@ -31,8 +31,6 @@ export default class TestSubAccountInfo implements HexaSubAccountDescribing {
   customDisplayName: string | null;
   customDescription: string | null;
 
-  avatarImageSource = require('../../../../../assets/images/icons/icon_test.png');
-
   transactions: TransactionDetails[];
   utxoCompatibilityGroup: UTXOCompatibilityGroup =
     UTXOCompatibilityGroup.TESTNET;

--- a/src/common/data/models/SubAccountInfo/HexaSubAccounts/TrustedContactsSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/HexaSubAccounts/TrustedContactsSubAccountInfo.ts
@@ -34,8 +34,6 @@ export default class TrustedContactsSubAccountInfo
   customDisplayName: string | null;
   customDescription: string | null;
 
-  avatarImageSource: ImageSourcePropType;
-
   transactions: TransactionDetails[];
   utxoCompatibilityGroup: UTXOCompatibilityGroup;
 
@@ -63,8 +61,5 @@ export default class TrustedContactsSubAccountInfo
     this.isTFAEnabled = isTFAEnabled;
     this.transactions = transactions;
     this.utxoCompatibilityGroup = utxoCompatibilityGroup;
-
-    // TODO: Define some way to generate this from the address book avatar.
-    this.avatarImageSource = require('../../../../../assets/images/icons/icon_hexa.png');
   }
 }

--- a/src/common/data/models/SubAccountInfo/ImportedWalletSubAccounts/FullyImportedWalletSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/ImportedWalletSubAccounts/FullyImportedWalletSubAccountInfo.ts
@@ -33,8 +33,6 @@ export default class FullyImportedWalletSubAccountInfo
   customDisplayName: string | null;
   customDescription: string | null;
 
-  avatarImageSource = require('../../../../../assets/images/icons/icon_wallet.png');
-
   transactions: TransactionDetails[];
   utxoCompatibilityGroup: UTXOCompatibilityGroup =
     UTXOCompatibilityGroup.SINGLE_SIG_PUBLIC;

--- a/src/common/data/models/SubAccountInfo/ImportedWalletSubAccounts/WatchOnlyImportedWalletSubAccountInfo.ts
+++ b/src/common/data/models/SubAccountInfo/ImportedWalletSubAccounts/WatchOnlyImportedWalletSubAccountInfo.ts
@@ -33,8 +33,6 @@ export default class WatchOnlyImportedWalletSubAccountInfo
   customDisplayName: string | null;
   customDescription: string | null;
 
-  avatarImageSource = require('../../../../../assets/images/icons/icon_import_watch_only_wallet.png');
-
   transactions: TransactionDetails[];
   utxoCompatibilityGroup: UTXOCompatibilityGroup =
     UTXOCompatibilityGroup.SINGLE_SIG_PUBLIC;

--- a/src/common/data/models/SubAccountInfo/Interfaces.ts
+++ b/src/common/data/models/SubAccountInfo/Interfaces.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from 'uuid';
 import SubAccountKind from '../../enums/SubAccountKind';
 import ServiceAccountKind from '../../enums/ServiceAccountKind';
 import UTXOCompatibilityGroup from '../../enums/UTXOCompatibilityGroup';
@@ -58,8 +57,6 @@ interface SubAccountDescribing {
    */
   isTFAEnabled: boolean;
 
-  avatarImageSource: ImageSourcePropType;
-
   utxoCompatibilityGroup: UTXOCompatibilityGroup;
   // transactionIDs: string[];
   transactions: TransactionDetails[];
@@ -90,7 +87,6 @@ export type SubAccountDescribingConstructorProps = {
   balances?: Balances;
   visibility?: AccountVisibility;
   isTFAEnabled?: boolean;
-  avatarImageSource?: ImageSourcePropType;
   secondaryAccountUUIDs?: string[];
   utxoCompatibilityGroup?: UTXOCompatibilityGroup;
   transactions?: TransactionDetails[];

--- a/src/common/data/models/interfaces/RecipientDescribing.ts
+++ b/src/common/data/models/interfaces/RecipientDescribing.ts
@@ -2,7 +2,7 @@ import { ImageSourcePropType } from 'react-native';
 import RecipientKind from '../../enums/RecipientKind';
 import { Satoshis } from '../../typealiases/UnitAliases';
 import ContactTrustKind from '../../enums/ContactTrustKind';
-import getAvatarForSubAccountKind from '../../../../utils/accounts/GetAvatarForSubAccountKind';
+import getAvatarForDeprecatedSubAccountKind from '../../../../utils/accounts/GetAvatarForDeprecatedSubAccountKind';
 
 export interface RecipientDescribing {
   id: string;
@@ -45,7 +45,7 @@ export function makeSubAccountRecipientDescription(
     id: data.id,
     kind: RecipientKind.SUB_ACCOUNT,
     displayedName: data.account_name || data.id,
-    avatarImageSource: getAvatarForSubAccountKind(accountKind),
+    avatarImageSource: getAvatarForDeprecatedSubAccountKind(accountKind),
     availableBalance: data.bitcoinAmount || data.amount || 0,
     initiatedAt: data.initiatedAt,
   };

--- a/src/components/account-details/AccountDetailsCard.tsx
+++ b/src/components/account-details/AccountDetailsCard.tsx
@@ -17,6 +17,7 @@ import { Button } from 'react-native-elements';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import AccountShell from '../../common/data/models/AccountShell';
 import usePrimarySubAccountForShell from '../../utils/hooks/account-utils/UsePrimarySubAccountForShell';
+import getAvatarForSubAccount from '../../utils/accounts/GetAvatarForSubAccountKind';
 
 export type Props = {
   accountShell: AccountShell;
@@ -75,7 +76,7 @@ const AccountDetailsCard: React.FC<Props> = ({
       <View style={styles.accountKindDetailsSection}>
         <View style={{ flexDirection: 'row', alignItems: 'flex-start' }}>
           <Image
-            source={primarySubAccountInfo.avatarImageSource}
+            source={getAvatarForSubAccount(primarySubAccountInfo)}
             style={styles.accountKindBadgeImage}
           />
 

--- a/src/components/account-settings/AccountMergeDestinationListItemContent.tsx
+++ b/src/components/account-settings/AccountMergeDestinationListItemContent.tsx
@@ -5,6 +5,7 @@ import AccountShell from '../../common/data/models/AccountShell';
 import ListStyles from '../../common/Styles/ListStyles';
 import ImageStyles from '../../common/Styles/ImageStyles';
 import usePrimarySubAccountForShell from '../../utils/hooks/account-utils/UsePrimarySubAccountForShell';
+import getAvatarForSubAccount from '../../utils/accounts/GetAvatarForSubAccountKind';
 
 export type Props = {
   accountShell: AccountShell;
@@ -18,7 +19,7 @@ const AccountMergeDestinationListItemContent: React.FC<Props> = ({
   return (
     <>
       <Image
-        source={primarySubAccount.avatarImageSource}
+        source={getAvatarForSubAccount(primarySubAccount)}
         style={styles.avatarImage}
         resizeMode="contain"
       />

--- a/src/components/account-settings/DesignatedSourceListItemContent.tsx
+++ b/src/components/account-settings/DesignatedSourceListItemContent.tsx
@@ -4,6 +4,7 @@ import { ListItem, Avatar } from 'react-native-elements';
 import SubAccountDescribing from '../../common/data/models/SubAccountInfo/Interfaces';
 import ListStyles from '../../common/Styles/ListStyles';
 import ImageStyles from '../../common/Styles/ImageStyles';
+import getAvatarForSubAccount from '../../utils/accounts/GetAvatarForSubAccountKind';
 
 export type Props = {
   subAccountInfo: SubAccountDescribing;
@@ -15,7 +16,7 @@ const DesignatedSourceListItemContent: React.FC<Props> = ({
   return (
     <>
       <Image
-        source={subAccountInfo.avatarImageSource}
+        source={getAvatarForSubAccount(subAccountInfo)}
         style={styles.avatarImage}
         resizeMode="contain"
       />

--- a/src/components/account-settings/DestinationAccountShellListItemContent.tsx
+++ b/src/components/account-settings/DestinationAccountShellListItemContent.tsx
@@ -5,6 +5,7 @@ import SubAccountKind from '../../common/data/enums/SubAccountKind';
 import SubAccountDescribing from '../../common/data/models/SubAccountInfo/Interfaces';
 import ListStyles from '../../common/Styles/ListStyles';
 import ImageStyles from '../../common/Styles/ImageStyles';
+import getAvatarForSubAccount from '../../utils/accounts/GetAvatarForSubAccountKind';
 
 export type Props = {
   subAccountInfo: SubAccountDescribing;
@@ -17,7 +18,7 @@ const DestinationAccountShellListItemContent: React.FC<Props> = ({
   return (
     <>
       <Image
-        source={subAccountInfo.avatarImageSource}
+        source={getAvatarForSubAccount(subAccountInfo)}
         style={styles.avatarImage}
         resizeMode="contain"
       />

--- a/src/components/account-settings/merge-account-shells/AccountShellMergeSelectionListHeader.tsx
+++ b/src/components/account-settings/merge-account-shells/AccountShellMergeSelectionListHeader.tsx
@@ -8,6 +8,7 @@ import Fonts from '../../../common/Fonts';
 import AccountShell from '../../../common/data/models/AccountShell';
 import usePrimarySubAccountForShell from '../../../utils/hooks/account-utils/UsePrimarySubAccountForShell';
 import { RFValue } from 'react-native-responsive-fontsize';
+import getAvatarForSubAccount from '../../../utils/accounts/GetAvatarForSubAccountKind';
 
 export type Props = {
   sourceShell: AccountShell;
@@ -24,7 +25,7 @@ const AccountShellMergeSelectionListHeader: React.FC<Props> = ({
       <ListItem pad={4} containerStyle={{ marginBottom: 36 }}>
 
         <Image
-          source={primarySubAccount.avatarImageSource}
+          source={getAvatarForSubAccount(primarySubAccount)}
           style={styles.avatarImage}
           resizeMode="contain"
         />

--- a/src/components/accounts/SubAccountOptionCard.tsx
+++ b/src/components/accounts/SubAccountOptionCard.tsx
@@ -6,6 +6,7 @@ import { RFValue } from 'react-native-responsive-fontsize';
 import CardStyles from '../../common/Styles/Cards.js';
 import LinearGradient from 'react-native-linear-gradient';
 import SubAccountDescribing from '../../common/data/models/SubAccountInfo/Interfaces';
+import getAvatarForSubAccount from '../../utils/accounts/GetAvatarForSubAccountKind';
 
 export interface Props {
   subAccountInfo: SubAccountDescribing;
@@ -73,7 +74,7 @@ const SubAccountOptionCard: React.FC<Props> = ({
       >
         <Image
           style={styles.image}
-          source={subAccountInfo.avatarImageSource}
+          source={getAvatarForSubAccount(subAccountInfo)}
         />
 
         <View style={styles.descriptionTextContainer}>

--- a/src/components/bottom-sheets/account-management/AccountShellMergeSuccessBottomSheet.tsx
+++ b/src/components/bottom-sheets/account-management/AccountShellMergeSuccessBottomSheet.tsx
@@ -10,6 +10,7 @@ import BottomSheetStyles from '../../../common/Styles/BottomSheetStyles';
 import AccountShell from '../../../common/data/models/AccountShell';
 import usePrimarySubAccountForShell from '../../../utils/hooks/account-utils/UsePrimarySubAccountForShell';
 import { RFValue } from 'react-native-responsive-fontsize';
+import getAvatarForSubAccount from '../../../utils/accounts/GetAvatarForSubAccountKind';
 
 
 export type Props = {
@@ -30,7 +31,7 @@ const AccountShellItem: React.FC<ItemProps> = ({
   return (
     <ListItem>
       <Image
-        source={primarySubAccount.avatarImageSource}
+        source={getAvatarForSubAccount(primarySubAccount)}
         style={styles.avatarImage}
         resizeMode="contain"
       />

--- a/src/components/home/HomeAccountsListCard.tsx
+++ b/src/components/home/HomeAccountsListCard.tsx
@@ -12,6 +12,7 @@ import usePrimarySubAccountForShell from '../../utils/hooks/account-utils/UsePri
 import useSecondarySubAccountsForShell from '../../utils/hooks/account-utils/UseSecondarySubAccountForShell';
 import useTotalBalanceForAccountShell from '../../utils/hooks/state-selectors/accounts/UseTotalBalanceForAccountShell';
 import SubAccountKind from '../../common/data/enums/SubAccountKind';
+import getAvatarForSubAccount from '../../utils/accounts/GetAvatarForSubAccountKind';
 
 
 export type Props = {
@@ -29,14 +30,15 @@ const HeaderSection: React.FC<HeaderProps> = ({
   const secondarySubAccounts = useSecondarySubAccountsForShell(accountShell);
 
   const secondarySubAccountBadgeIcons: ImageSourcePropType[] = useMemo(() => {
-    return secondarySubAccounts.map(subAccount => subAccount.avatarImageSource);
+    return secondarySubAccounts
+      .map(subAccount => getAvatarForSubAccount(subAccount));
   }, [secondarySubAccounts])
 
   return (
     <View style={styles.headerSectionContainer}>
       <Image
         style={styles.headerAccountImage}
-        source={primarySubAccount.avatarImageSource}
+        source={getAvatarForSubAccount(primarySubAccount)}
       />
 
       <View style={styles.headerBadgeContainer}>

--- a/src/components/more-options/account-management/ReorderAccountShellsDraggableListItem.tsx
+++ b/src/components/more-options/account-management/ReorderAccountShellsDraggableListItem.tsx
@@ -5,6 +5,7 @@ import usePrimarySubAccountForShell from '../../../utils/hooks/account-utils/Use
 import { ListItem } from 'react-native-elements';
 import ListStyles from '../../../common/Styles/ListStyles';
 import ImageStyles from '../../../common/Styles/ImageStyles';
+import getAvatarForSubAccount from '../../../utils/accounts/GetAvatarForSubAccountKind';
 
 export type Props = {
   accountShell: AccountShell;
@@ -22,7 +23,7 @@ const ReorderAccountShellsDraggableListItem: React.FC<Props> = ({
   return (
     <ListItem onLongPress={onLongPress} style={containerStyle}>
       <Image
-        source={primarySubAccount.avatarImageSource}
+        source={getAvatarForSubAccount(primarySubAccount)}
         style={ImageStyles.thumbnailImageMedium}
         resizeMode="contain"
       />

--- a/src/pages/Accounts/Transactions/TransactionDetailsHeader.tsx
+++ b/src/pages/Accounts/Transactions/TransactionDetailsHeader.tsx
@@ -10,6 +10,7 @@ import ImageStyles from '../../../common/Styles/ImageStyles';
 import ListStyles from '../../../common/Styles/ListStyles';
 import { Icon } from 'react-native-elements';
 import TransactionKind from '../../../common/data/enums/TransactionKind';
+import getAvatarForSubAccount from '../../../utils/accounts/GetAvatarForSubAccountKind';
 
 export type Props = {
   transaction: TransactionDescribing;
@@ -48,7 +49,7 @@ const TransactionDetailsHeader: React.FC<Props> = ({
     <View style={styles.rootContainer}>
       <View style={styles.contentContainer}>
         <Image
-          source={primarySubAccount.avatarImageSource}
+          source={getAvatarForSubAccount(primarySubAccount)}
           style={styles.avatarImage}
           resizeMode="contain"
         />

--- a/src/utils/accounts/GetAvatarForDeprecatedSubAccountKind.ts
+++ b/src/utils/accounts/GetAvatarForDeprecatedSubAccountKind.ts
@@ -1,0 +1,23 @@
+import { ImageSourcePropType } from "react-native";
+import SubAccountKind from "../../common/data/enums/SubAccountKind";
+
+/**
+ * TODO: Deprecate this in favor of calling `getIconByAccountKind` with a
+ * a strongly-typed `AccountKind`.
+ * (See: https://github.com/bithyve/hexa/blob/f247ab7ae05e52e23ec4fc773360ef84a063248f/src/utils/accounts/IconUtils.ts#L23)
+ */
+export default function getAvatarForDeprecatedSubAccountKind(accountKind: string): ImageSourcePropType | null {
+  if (['saving', 'SAVINGS_ACCOUNT'].includes(accountKind)) {
+    return require('../../assets/images/icons/icon_secureaccount.png');
+  } else if (['regular', 'REGULAR_ACCOUNT'].includes(accountKind)) {
+    return require('../../assets/images/icons/icon_regular.png');
+  } else if (['secure', 'SECURE_ACCOUNT'].includes(accountKind)) {
+    return require('../../assets/images/icons/icon_secureaccount.png');
+  } else if (['test', 'TEST_ACCOUNT'].includes(accountKind)) {
+    return require('../../assets/images/icons/icon_test.png');
+  } else if (['Donation Account', 'DONATION_ACCOUNT'].includes(accountKind)) {
+    return require('../../assets/images/icons/icon_donation_hexa.png');
+  }
+};
+
+

--- a/src/utils/accounts/GetAvatarForServiceAccountKind.ts
+++ b/src/utils/accounts/GetAvatarForServiceAccountKind.ts
@@ -1,0 +1,15 @@
+import { ImageSourcePropType } from "react-native";
+import ServiceAccountKind from "../../common/data/enums/ServiceAccountKind";
+
+export default function getAvatarForServiceAccountKind(
+  serviceAccountKind: ServiceAccountKind,
+): ImageSourcePropType {
+  switch (serviceAccountKind) {
+    case ServiceAccountKind.FAST_BITCOINS:
+      return require('../../assets/images/icons/icon_fastbitcoins_hex_dark.png');
+    case ServiceAccountKind.SWAN:
+      return require('../../assets/images/icons/icon_swan.png');
+    default:
+      return require('../../assets/images/icons/icon_hexa.png');
+  }
+}

--- a/src/utils/accounts/GetAvatarForSubAccountKind.ts
+++ b/src/utils/accounts/GetAvatarForSubAccountKind.ts
@@ -1,20 +1,30 @@
 import { ImageSourcePropType } from "react-native";
+import SubAccountKind from "../../common/data/enums/SubAccountKind";
+import ExternalServiceSubAccountInfo from "../../common/data/models/SubAccountInfo/ExternalServiceSubAccountInfo";
+import SubAccountDescribing from "../../common/data/models/SubAccountInfo/Interfaces";
+import getAvatarForServiceAccountKind from "./GetAvatarForServiceAccountKind";
 
-/**
- * TODO: Deprecate this in favor of calling `getIconByAccountKind` with a
- * a strongly-typed `AccountKind`.
- * (See: https://github.com/bithyve/hexa/blob/f247ab7ae05e52e23ec4fc773360ef84a063248f/src/utils/accounts/IconUtils.ts#L23)
- */
-export default function getAvatarForSubAccountKind(accountKind: string): ImageSourcePropType | null {
-  if (['saving', 'SAVINGS_ACCOUNT'].includes(accountKind)) {
-    return require('../../assets/images/icons/icon_secureaccount.png');
-  } else if (['regular', 'REGULAR_ACCOUNT'].includes(accountKind)) {
-    return require('../../assets/images/icons/icon_regular.png');
-  } else if (['secure', 'SECURE_ACCOUNT'].includes(accountKind)) {
-    return require('../../assets/images/icons/icon_secureaccount.png');
-  } else if (['test', 'TEST_ACCOUNT'].includes(accountKind)) {
-    return require('../../assets/images/icons/icon_test.png');
-  } else if (['Donation Account', 'DONATION_ACCOUNT'].includes(accountKind)) {
-    return require('../../assets/images/icons/icon_donation_hexa.png');
+export default function getAvatarForSubAccount(
+  subAccount: SubAccountDescribing
+): ImageSourcePropType {
+  switch (subAccount.kind) {
+    case SubAccountKind.TEST_ACCOUNT:
+      return require('../../assets/images/icons/icon_test.png');
+    case SubAccountKind.REGULAR_ACCOUNT:
+      return require('../../assets/images/icons/icon_regular.png');
+    case SubAccountKind.SECURE_ACCOUNT:
+      return require('../../assets/images/icons/icon_secureaccount.png');
+    case SubAccountKind.TRUSTED_CONTACTS:
+      return require('../../assets/images/icons/icon_hexa.png');
+    case SubAccountKind.DONATION_ACCOUNT:
+      return require('../../assets/images/icons/icon_donation_hexa.png');
+    case SubAccountKind.WATCH_ONLY_IMPORTED_WALLET:
+      return require('../../assets/images/icons/icon_import_watch_only_wallet.png');
+    case SubAccountKind.FULLY_IMPORTED_WALLET:
+      return require('../../assets/images/icons/icon_wallet.png');
+    case SubAccountKind.SERVICE:
+      return getAvatarForServiceAccountKind((subAccount as ExternalServiceSubAccountInfo).serviceAccountKind)
+    default:
+      return require('../../assets/images/icons/icon_hexa.png');
   }
 };


### PR DESCRIPTION
Connected to https://github.com/bithyve/hexa/issues/2244.

This [SO answer](https://stackoverflow.com/questions/55056305/react-native-image-doesnt-render-local-source#comment96865028_55056305) provides good insight into what's being solved here. 

We're currently hard-coding an asset path when the account is initialized and trying to persist that with Redux, but I don't think we can rely on that path always resolving to the right image as things move around on the device's file system. Looking up the path dynamically at runtime, however, hopefully, will get around this.