### PR TITLE
Debounces the tap handling on Account Details transactions list items.

### DIFF
--- a/ios/HEXA.xcodeproj/project.pbxproj
+++ b/ios/HEXA.xcodeproj/project.pbxproj
@@ -8,11 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		0ABCF5EEB6A24513A21B391F /* OpenSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 599B38ECC3EC4E4CB38D4C8A /* OpenSans-Bold.ttf */; };
+		118FB4404DC7A95BCA6F33E8 /* libPods-HEXA Stage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E912FA30DBD64542F396F86 /* libPods-HEXA Stage.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		1ADDFE9EF1EA44B39CDB9BC2 /* OpenSans-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AD12BB582E724B3887BFFE64 /* OpenSans-Light.ttf */; };
 		2F039E5F6FF845818DEC1F4D /* OpenSans-SemiboldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DAD1674B7394413A82B21AF7 /* OpenSans-SemiboldItalic.ttf */; };
+		38686007409961767DCBD665 /* libPods-HEXA Dev.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A75676B29C5D1774100CECA1 /* libPods-HEXA Dev.a */; };
 		5A9A412432B34690AD199B59 /* FiraSans-BookItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A35E966FF3B347CFA2E0CBE5 /* FiraSans-BookItalic.ttf */; };
 		6111482F2506463F00ED433D /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6111482E2506463F00ED433D /* CloudKit.framework */; };
 		611148352506478E00ED433D /* PdfGenerate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611148312506478E00ED433D /* PdfGenerate.swift */; };
@@ -68,52 +70,47 @@
 		61B5223F25076DF5002F73B2 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 619CF232250654E300A8E6DF /* GoogleService-Info.plist */; };
 		656E35D57E0B42E8B8745C5C /* OpenSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 466F94D18D9449A8957F3610 /* OpenSans-Regular.ttf */; };
 		6FE58ECD5691497784662337 /* FiraSans-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D3784CB53EE4E7D914C42B4 /* FiraSans-SemiBold.ttf */; };
-		7B66DF4CEEB7BD63F44017BD /* libPods-HEXA.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2928EB57446ACE4788DA1866 /* libPods-HEXA.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		84C34D93035D4E8CA3855535 /* FiraSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 262894C9A21E4EE48406A1D0 /* FiraSans-Bold.ttf */; };
 		931F7A4365DF468BADA226D2 /* OpenSans-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DF7107F6EA2D4846A469A116 /* OpenSans-Semibold.ttf */; };
 		A0647B856EF5484EB9D37E71 /* FiraSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7BBFAA85840C4C369964BD81 /* FiraSans-Regular.ttf */; };
 		AA11C3A22548270900B032D1 /* HEXA.Dev-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AA11C3A12548270900B032D1 /* HEXA.Dev-Info.plist */; };
 		AA11C3A42548271A00B032D1 /* HEXA.Stage-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AA11C3A32548271A00B032D1 /* HEXA.Stage-Info.plist */; };
-		B8B695B13EC854432AE7EADB /* libPods-HEXA Dev.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E5A7F0676B7FB20C181DD50 /* libPods-HEXA Dev.a */; };
 		B8D1041D05D6411F9D52E7D6 /* OpenSans-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9E29DABD5A154C1997E9AD44 /* OpenSans-BoldItalic.ttf */; };
 		C0D2EBAD35E54C34BB47A2C0 /* FiraSans-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 158EFB7281D64BD3B2F784B3 /* FiraSans-MediumItalic.ttf */; };
 		DF98272D8CB14F19972464BB /* OpenSans-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 96E40822F039459A97686C32 /* OpenSans-Italic.ttf */; };
 		E59524329FB64B6B9EB4F44A /* FiraSans-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E2EDF28037624796A9996D82 /* FiraSans-Italic.ttf */; };
+		E984B09335AB21084B90578C /* libPods-HEXA.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A308B545C00CD4D2F96A820 /* libPods-HEXA.a */; };
 		EC871328B5214142B36CC294 /* FiraSans-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9A4E6F5E9B5642DD8E860F82 /* FiraSans-Medium.ttf */; };
 		ECA21601D47443C3B3738345 /* OpenSans-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F727B7636E8440F1BC2C78B2 /* OpenSans-LightItalic.ttf */; };
-		F9B7ADE35D5663A9119C0FD2 /* libPods-HEXA Stage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 526A62373F647DAAE3685BD3 /* libPods-HEXA Stage.a */; };
 		FC9848DE447644B59209F6C3 /* OpenSans-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 39CE481CEF614843B40E1EC5 /* OpenSans-ExtraBold.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* HEXATests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HEXATests.m; sourceTree = "<group>"; };
-		045F58FB6EADCC60DCBA3CF9 /* Pods-HEXA Dev.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA Dev.debug.xcconfig"; path = "Target Support Files/Pods-HEXA Dev/Pods-HEXA Dev.debug.xcconfig"; sourceTree = "<group>"; };
+		0879A215956D9B36AF542A8B /* Pods-HEXA Dev.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA Dev.release.xcconfig"; path = "Target Support Files/Pods-HEXA Dev/Pods-HEXA Dev.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Hexa.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hexa.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = HEXA/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = HEXA/AppDelegate.m; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HEXA/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HEXA/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = HEXA/main.m; sourceTree = "<group>"; };
-		156A997303CCA27180E9E859 /* Pods-HEXA Stage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA Stage.debug.xcconfig"; path = "Target Support Files/Pods-HEXA Stage/Pods-HEXA Stage.debug.xcconfig"; sourceTree = "<group>"; };
 		158EFB7281D64BD3B2F784B3 /* FiraSans-MediumItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "FiraSans-MediumItalic.ttf"; path = "../src/assets/fonts/FiraSans-MediumItalic.ttf"; sourceTree = "<group>"; };
 		1BDE786A62844DE89D7EE379 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
 		227A2A160AEE42F4999170A1 /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialCommunityIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
-		24FFFBCDEA6C9E3AD090D6B0 /* Pods-HEXA Dev.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA Dev.release.xcconfig"; path = "Target Support Files/Pods-HEXA Dev/Pods-HEXA Dev.release.xcconfig"; sourceTree = "<group>"; };
 		262894C9A21E4EE48406A1D0 /* FiraSans-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "FiraSans-Bold.ttf"; path = "../src/assets/fonts/FiraSans-Bold.ttf"; sourceTree = "<group>"; };
-		2928EB57446ACE4788DA1866 /* libPods-HEXA.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HEXA.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2952F3993041452D93FA88B9 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
-		34076E02258E37BD896EA9E1 /* Pods-HEXA.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA.debug.xcconfig"; path = "Target Support Files/Pods-HEXA/Pods-HEXA.debug.xcconfig"; sourceTree = "<group>"; };
+		2E912FA30DBD64542F396F86 /* libPods-HEXA Stage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HEXA Stage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		39CE481CEF614843B40E1EC5 /* OpenSans-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-ExtraBold.ttf"; path = "../src/assets/fonts/OpenSans-ExtraBold.ttf"; sourceTree = "<group>"; };
-		447AD7168B3C86C83490561E /* Pods-HEXA Stage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA Stage.release.xcconfig"; path = "Target Support Files/Pods-HEXA Stage/Pods-HEXA Stage.release.xcconfig"; sourceTree = "<group>"; };
 		466F94D18D9449A8957F3610 /* OpenSans-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-Regular.ttf"; path = "../src/assets/fonts/OpenSans-Regular.ttf"; sourceTree = "<group>"; };
 		4D3784CB53EE4E7D914C42B4 /* FiraSans-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "FiraSans-SemiBold.ttf"; path = "../src/assets/fonts/FiraSans-SemiBold.ttf"; sourceTree = "<group>"; };
-		526A62373F647DAAE3685BD3 /* libPods-HEXA Stage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HEXA Stage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5368C798ABC9BD624DF7DE05 /* Pods-HEXA Stage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA Stage.release.xcconfig"; path = "Target Support Files/Pods-HEXA Stage/Pods-HEXA Stage.release.xcconfig"; sourceTree = "<group>"; };
 		5395FCDF04064C3DBEEE4A64 /* FontAwesome5_Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Regular.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf"; sourceTree = "<group>"; };
 		559C9AB9CDAC4F3FA05EC3FE /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
 		57F664D38343416FB1C55280 /* Zocial.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Zocial.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; };
 		599B38ECC3EC4E4CB38D4C8A /* OpenSans-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-Bold.ttf"; path = "../src/assets/fonts/OpenSans-Bold.ttf"; sourceTree = "<group>"; };
+		5A308B545C00CD4D2F96A820 /* libPods-HEXA.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HEXA.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6111482E2506463F00ED433D /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		611148312506478E00ED433D /* PdfGenerate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PdfGenerate.swift; sourceTree = "<group>"; };
 		61114838250647BD00ED433D /* PdfPassword.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PdfPassword.h; sourceTree = "<group>"; };
@@ -127,23 +124,26 @@
 		619CF234250654F600A8E6DF /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "GoogleServicesPlist/Development/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		67A86A5BF4334540878AED10 /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
 		6A234933673440BFB6559B6D /* FontAwesome5_Solid.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Solid.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf"; sourceTree = "<group>"; };
-		6E5A7F0676B7FB20C181DD50 /* libPods-HEXA Dev.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HEXA Dev.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B5C2AAF9659F113AC39BD8B /* Pods-HEXA.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA.release.xcconfig"; path = "Target Support Files/Pods-HEXA/Pods-HEXA.release.xcconfig"; sourceTree = "<group>"; };
 		70412DE9AEA54C18972F9DD5 /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
 		7BBFAA85840C4C369964BD81 /* FiraSans-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "FiraSans-Regular.ttf"; path = "../src/assets/fonts/FiraSans-Regular.ttf"; sourceTree = "<group>"; };
+		80E5568734997212700125B6 /* Pods-HEXA Stage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA Stage.debug.xcconfig"; path = "Target Support Files/Pods-HEXA Stage/Pods-HEXA Stage.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = HEXA/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8A1B98A7327A4AD8A5860B74 /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
+		90E106A638A243BCB686004D /* Pods-HEXA Dev.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA Dev.debug.xcconfig"; path = "Target Support Files/Pods-HEXA Dev/Pods-HEXA Dev.debug.xcconfig"; sourceTree = "<group>"; };
 		917A2A003A01429481FD026C /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
 		96E40822F039459A97686C32 /* OpenSans-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-Italic.ttf"; path = "../src/assets/fonts/OpenSans-Italic.ttf"; sourceTree = "<group>"; };
 		9A4E6F5E9B5642DD8E860F82 /* FiraSans-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "FiraSans-Medium.ttf"; path = "../src/assets/fonts/FiraSans-Medium.ttf"; sourceTree = "<group>"; };
 		9E29DABD5A154C1997E9AD44 /* OpenSans-BoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-BoldItalic.ttf"; path = "../src/assets/fonts/OpenSans-BoldItalic.ttf"; sourceTree = "<group>"; };
 		A35E966FF3B347CFA2E0CBE5 /* FiraSans-BookItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "FiraSans-BookItalic.ttf"; path = "../src/assets/fonts/FiraSans-BookItalic.ttf"; sourceTree = "<group>"; };
+		A75676B29C5D1774100CECA1 /* libPods-HEXA Dev.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HEXA Dev.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA11C3A12548270900B032D1 /* HEXA.Dev-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "HEXA.Dev-Info.plist"; path = "HEXA/HEXA.Dev-Info.plist"; sourceTree = "<group>"; };
 		AA11C3A32548271A00B032D1 /* HEXA.Stage-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "HEXA.Stage-Info.plist"; path = "HEXA/HEXA.Stage-Info.plist"; sourceTree = "<group>"; };
 		AD12BB582E724B3887BFFE64 /* OpenSans-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-Light.ttf"; path = "../src/assets/fonts/OpenSans-Light.ttf"; sourceTree = "<group>"; };
 		C1B0A87F089E485685570E93 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
 		C88B0D378D49456C80224451 /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		C8BC543B70204B8FB3B09520 /* Fontisto.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Fontisto.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Fontisto.ttf"; sourceTree = "<group>"; };
-		CFB1182FB329D5C39B7D0905 /* Pods-HEXA.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA.release.xcconfig"; path = "Target Support Files/Pods-HEXA/Pods-HEXA.release.xcconfig"; sourceTree = "<group>"; };
+		CE656B0100CD596D6B1CB74E /* Pods-HEXA.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HEXA.debug.xcconfig"; path = "Target Support Files/Pods-HEXA/Pods-HEXA.debug.xcconfig"; sourceTree = "<group>"; };
 		D242AB8F3F014E068BE8C13D /* FontAwesome5_Brands.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Brands.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf"; sourceTree = "<group>"; };
 		DAD1674B7394413A82B21AF7 /* OpenSans-SemiboldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-SemiboldItalic.ttf"; path = "../src/assets/fonts/OpenSans-SemiboldItalic.ttf"; sourceTree = "<group>"; };
 		DF7107F6EA2D4846A469A116 /* OpenSans-Semibold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-Semibold.ttf"; path = "../src/assets/fonts/OpenSans-Semibold.ttf"; sourceTree = "<group>"; };
@@ -160,7 +160,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6111482F2506463F00ED433D /* CloudKit.framework in Frameworks */,
-				7B66DF4CEEB7BD63F44017BD /* libPods-HEXA.a in Frameworks */,
+				E984B09335AB21084B90578C /* libPods-HEXA.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,7 +169,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6182F77B250B23D7005B6ECE /* CloudKit.framework in Frameworks */,
-				B8B695B13EC854432AE7EADB /* libPods-HEXA Dev.a in Frameworks */,
+				38686007409961767DCBD665 /* libPods-HEXA Dev.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,7 +178,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6182F7A7250B2742005B6ECE /* CloudKit.framework in Frameworks */,
-				F9B7ADE35D5663A9119C0FD2 /* libPods-HEXA Stage.a in Frameworks */,
+				118FB4404DC7A95BCA6F33E8 /* libPods-HEXA Stage.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -231,9 +231,9 @@
 				6111482E2506463F00ED433D /* CloudKit.framework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
-				2928EB57446ACE4788DA1866 /* libPods-HEXA.a */,
-				6E5A7F0676B7FB20C181DD50 /* libPods-HEXA Dev.a */,
-				526A62373F647DAAE3685BD3 /* libPods-HEXA Stage.a */,
+				5A308B545C00CD4D2F96A820 /* libPods-HEXA.a */,
+				A75676B29C5D1774100CECA1 /* libPods-HEXA Dev.a */,
+				2E912FA30DBD64542F396F86 /* libPods-HEXA Stage.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -274,12 +274,12 @@
 		9FD0418BDBDF3D36477ED773 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				34076E02258E37BD896EA9E1 /* Pods-HEXA.debug.xcconfig */,
-				CFB1182FB329D5C39B7D0905 /* Pods-HEXA.release.xcconfig */,
-				045F58FB6EADCC60DCBA3CF9 /* Pods-HEXA Dev.debug.xcconfig */,
-				24FFFBCDEA6C9E3AD090D6B0 /* Pods-HEXA Dev.release.xcconfig */,
-				156A997303CCA27180E9E859 /* Pods-HEXA Stage.debug.xcconfig */,
-				447AD7168B3C86C83490561E /* Pods-HEXA Stage.release.xcconfig */,
+				CE656B0100CD596D6B1CB74E /* Pods-HEXA.debug.xcconfig */,
+				6B5C2AAF9659F113AC39BD8B /* Pods-HEXA.release.xcconfig */,
+				90E106A638A243BCB686004D /* Pods-HEXA Dev.debug.xcconfig */,
+				0879A215956D9B36AF542A8B /* Pods-HEXA Dev.release.xcconfig */,
+				80E5568734997212700125B6 /* Pods-HEXA Stage.debug.xcconfig */,
+				5368C798ABC9BD624DF7DE05 /* Pods-HEXA Stage.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -330,13 +330,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "HEXA" */;
 			buildPhases = (
-				4097993FD6CFEE3DAE97D5F9 /* [CP] Check Pods Manifest.lock */,
+				5FA5993580A93DFBF4335990 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				B77977742B15F1AA76FFF64C /* ShellScript */,
-				E12F493948CBE10A748B3AB0 /* [CP] Copy Pods Resources */,
+				32B355FE15DD53C2D625AE85 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -351,13 +351,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6182F793250B23D7005B6ECE /* Build configuration list for PBXNativeTarget "HEXA Dev" */;
 			buildPhases = (
-				F52D426515B29AA5521DA22D /* [CP] Check Pods Manifest.lock */,
+				B688A3E1E445C9A5C1713118 /* [CP] Check Pods Manifest.lock */,
 				6182F774250B23D7005B6ECE /* Start Packager */,
 				6182F775250B23D7005B6ECE /* Sources */,
 				6182F77A250B23D7005B6ECE /* Frameworks */,
 				6182F77D250B23D7005B6ECE /* Resources */,
 				6182F791250B23D7005B6ECE /* Bundle React Native code and images */,
-				4180A0FBC7578AABD0C54966 /* [CP] Copy Pods Resources */,
+				43A710135727955FA40DC077 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -372,13 +372,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6182F7BF250B2742005B6ECE /* Build configuration list for PBXNativeTarget "HEXA Stage" */;
 			buildPhases = (
-				941E79A9EACEFACDE0F282C4 /* [CP] Check Pods Manifest.lock */,
+				7EEE0FE045CA910E47BDEB40 /* [CP] Check Pods Manifest.lock */,
 				6182F7A0250B2742005B6ECE /* Start Packager */,
 				6182F7A1250B2742005B6ECE /* Sources */,
 				6182F7A6250B2742005B6ECE /* Frameworks */,
 				6182F7A9250B2742005B6ECE /* Resources */,
 				6182F7BD250B2742005B6ECE /* Bundle React Native code and images */,
-				297106F574BBDA02EFEF3928 /* [CP] Copy Pods Resources */,
+				C8A919961A2D8E8CDFFF3CD0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -530,13 +530,13 @@
 			shellPath = /bin/sh;
 			shellScript = "cd $PROJECT_DIR/..\nexport NODE_BINARY=node\n./node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
-		297106F574BBDA02EFEF3928 /* [CP] Copy Pods Resources */ = {
+		32B355FE15DD53C2D625AE85 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-HEXA Stage/Pods-HEXA Stage-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-HEXA/Pods-HEXA-resources.sh",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
@@ -577,32 +577,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HEXA Stage/Pods-HEXA Stage-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HEXA/Pods-HEXA-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4097993FD6CFEE3DAE97D5F9 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-HEXA-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4180A0FBC7578AABD0C54966 /* [CP] Copy Pods Resources */ = {
+		43A710135727955FA40DC077 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -650,6 +628,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HEXA Dev/Pods-HEXA Dev-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5FA5993580A93DFBF4335990 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HEXA-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6182F774250B23D7005B6ECE /* Start Packager */ = {
@@ -716,7 +716,7 @@
 			shellPath = /bin/sh;
 			shellScript = "cd $PROJECT_DIR/..\nexport NODE_BINARY=node\n./node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
-		941E79A9EACEFACDE0F282C4 /* [CP] Check Pods Manifest.lock */ = {
+		7EEE0FE045CA910E47BDEB40 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -732,6 +732,28 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-HEXA Stage-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B688A3E1E445C9A5C1713118 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HEXA Dev-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -771,13 +793,13 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HEXA/Pods-HEXA-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E12F493948CBE10A748B3AB0 /* [CP] Copy Pods Resources */ = {
+		C8A919961A2D8E8CDFFF3CD0 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-HEXA/Pods-HEXA-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-HEXA Stage/Pods-HEXA Stage-resources.sh",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
@@ -818,29 +840,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HEXA/Pods-HEXA-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F52D426515B29AA5521DA22D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-HEXA Dev-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HEXA Stage/Pods-HEXA Stage-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -884,7 +884,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 34076E02258E37BD896EA9E1 /* Pods-HEXA.debug.xcconfig */;
+			baseConfigurationReference = CE656B0100CD596D6B1CB74E /* Pods-HEXA.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -915,7 +915,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CFB1182FB329D5C39B7D0905 /* Pods-HEXA.release.xcconfig */;
+			baseConfigurationReference = 6B5C2AAF9659F113AC39BD8B /* Pods-HEXA.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -944,7 +944,7 @@
 		};
 		6182F794250B23D7005B6ECE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 045F58FB6EADCC60DCBA3CF9 /* Pods-HEXA Dev.debug.xcconfig */;
+			baseConfigurationReference = 90E106A638A243BCB686004D /* Pods-HEXA Dev.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Development";
 				CLANG_ENABLE_MODULES = YES;
@@ -980,7 +980,7 @@
 		};
 		6182F795250B23D7005B6ECE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 24FFFBCDEA6C9E3AD090D6B0 /* Pods-HEXA Dev.release.xcconfig */;
+			baseConfigurationReference = 0879A215956D9B36AF542A8B /* Pods-HEXA Dev.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Development";
 				CLANG_ENABLE_MODULES = YES;
@@ -1009,7 +1009,7 @@
 		};
 		6182F7C0250B2742005B6ECE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 156A997303CCA27180E9E859 /* Pods-HEXA Stage.debug.xcconfig */;
+			baseConfigurationReference = 80E5568734997212700125B6 /* Pods-HEXA Stage.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Staging";
 				CLANG_ENABLE_MODULES = YES;
@@ -1041,7 +1041,7 @@
 		};
 		6182F7C1250B2742005B6ECE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 447AD7168B3C86C83490561E /* Pods-HEXA Stage.release.xcconfig */;
+			baseConfigurationReference = 5368C798ABC9BD624DF7DE05 /* Pods-HEXA Stage.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Staging";
 				CLANG_ENABLE_MODULES = YES;

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "icepick": "^2.4.0",
     "idx": "^2.5.6",
     "jail-monkey": "^2.3.2",
+    "lodash": "^4.17.20",
     "moment": "^2.27.0",
     "path-browserify": "0.0.0",
     "process": "^0.11.10",

--- a/src/components/account-details/AccountDetailsTransactionsList.tsx
+++ b/src/components/account-details/AccountDetailsTransactionsList.tsx
@@ -1,33 +1,47 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useRef, useCallback } from 'react'
 import {
   FlatList,
   TouchableOpacity,
-} from 'react-native';
-import TransactionDescribing from '../../common/data/models/Transactions/Interfaces';
-import TransactionsListItem from './AccountDetailsTransactionsListItem';
+} from 'react-native'
+import _ from 'lodash'
+import TransactionDescribing from '../../common/data/models/Transactions/Interfaces'
+import TransactionsListItem from './AccountDetailsTransactionsListItem'
 
-const keyExtractor = (item: TransactionDescribing) => item.txid;
+const keyExtractor = ( item: TransactionDescribing ) => item.txid
 
 export type Props = {
   transactions: TransactionDescribing[];
-  onTransactionSelected: (transaction: TransactionDescribing) => void;
+  onTransactionSelected: ( transaction: TransactionDescribing ) => void;
 };
 
-const AccountDetailsTransactionsList: React.FC<Props> = ({
+const AccountDetailsTransactionsList: React.FC<Props> = ( {
   transactions,
   onTransactionSelected,
-}: Props) => {
-  const renderItem = ({
-    item: transaction,
-  }: {
+}: Props ) => {
+
+  /**
+   * Debounces the tap handling due to an issue where double-tapping triggered
+   * multiple navigations and caused the App component to unmount -- leading to
+   * the crash described here: https://github.com/bithyve/hexa/issues/2329
+   *
+   * (Further discussion can also be found in this thread: https://bithyve-workspace.slack.com/archives/CN7K6RY9Z/p1608213919048000)
+   */
+  const transactionSelectionHandler = useCallback(
+    _.debounce( ( transaction: TransactionDescribing ) => onTransactionSelected( transaction ), 200 ),
+    []
+  )
+
+  const renderItem = ( { item: transaction, }: {
     item: TransactionDescribing;
-  }): ReactElement => {
+  } ): ReactElement => {
     return (
-      <TouchableOpacity onPress={() => onTransactionSelected(transaction)}>
+      <TouchableOpacity
+        onPress={() => transactionSelectionHandler( transaction )}
+      >
         <TransactionsListItem transaction={transaction} />
       </TouchableOpacity>
-    );
-  };
+    )
+  }
 
   return (
     <FlatList
@@ -35,7 +49,7 @@ const AccountDetailsTransactionsList: React.FC<Props> = ({
       keyExtractor={keyExtractor}
       renderItem={renderItem}
     />
-  );
-};
+  )
+}
 
-export default AccountDetailsTransactionsList;
+export default AccountDetailsTransactionsList

--- a/src/pages/Accounts/Details/AccountDetailsContainerScreen.tsx
+++ b/src/pages/Accounts/Details/AccountDetailsContainerScreen.tsx
@@ -45,18 +45,18 @@ export type Props = {
   navigation: any;
 };
 
-const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
+const AccountDetailsContainerScreen: React.FC<Props> = ( { navigation } ) => {
   const dispatch = useDispatch()
 
-  const accountShellID = useMemo(() => {
-    return navigation.getParam('accountShellID')
-  }, [navigation])
+  const accountShellID = useMemo( () => {
+    return navigation.getParam( 'accountShellID' )
+  }, [ navigation ] )
 
-  const accountShell = useAccountShellFromNavigation(navigation)
+  const accountShell = useAccountShellFromNavigation( navigation )
   const accountsState = useAccountsState()
-  const primarySubAccount = usePrimarySubAccountForShell(accountShell)
-  const accountTransactions = AccountShell.getAllTransactions(accountShell)
-  const spendableBalance = useSpendableBalanceForAccountShell(accountShell)
+  const primarySubAccount = usePrimarySubAccountForShell( accountShell )
+  const accountTransactions = AccountShell.getAllTransactions( accountShell )
+  const spendableBalance = useSpendableBalanceForAccountShell( accountShell )
   const { averageTxFees, exchangeRates } = accountsState
   let derivativeAccountKind: any = primarySubAccount.kind
 
@@ -64,7 +64,7 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
     primarySubAccount.kind === SubAccountKind.REGULAR_ACCOUNT ||
     primarySubAccount.kind === SubAccountKind.SECURE_ACCOUNT
   ) {
-    if (primarySubAccount.instanceNumber) {
+    if ( primarySubAccount.instanceNumber ) {
       derivativeAccountKind = DerivativeAccountTypes.SUB_PRIMARY_ACCOUNT
     }
   }
@@ -72,58 +72,58 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
   const derivativeAccountDetails: {
     type: string;
     number: number;
-  } = config.EJECTED_ACCOUNTS.includes(derivativeAccountKind) ?
-      {
-        type: derivativeAccountKind,
-        number: primarySubAccount.instanceNumber,
-      }
-      : null
+  } = config.EJECTED_ACCOUNTS.includes( derivativeAccountKind ) ?
+    {
+      type: derivativeAccountKind,
+      number: primarySubAccount.instanceNumber,
+    }
+    : null
 
 
-  const isRefreshing = useMemo(() => {
+  const isRefreshing = useMemo( () => {
     return accountShell.isSyncInProgress
-  }, [accountShell.isSyncInProgress])
+  }, [ accountShell.isSyncInProgress ] )
 
   const {
     present: presentBottomSheet,
     dismiss: dismissBottomSheet,
   } = useBottomSheetModal()
 
-  function handleTransactionSelection(transaction: TransactionDescribing) {
-    navigation.navigate('TransactionDetails', {
+  function handleTransactionSelection( transaction: TransactionDescribing ) {
+    navigation.navigate( 'TransactionDetails', {
       transaction,
       accountShellID: accountShell.id,
-    })
+    } )
   }
 
   function navigateToTransactionsList() {
-    navigation.navigate('TransactionsList', {
+    navigation.navigate( 'TransactionsList', {
       accountShellID,
-    })
+    } )
   }
 
   function navigateToAccountSettings() {
-    navigation.navigate('SubAccountSettings', {
+    navigation.navigate( 'SubAccountSettings', {
       accountShellID,
-    })
+    } )
   }
 
-  function navigateToDonationAccountWebViewSettings(donationAccount, accountNumber, serviceType) {
+  function navigateToDonationAccountWebViewSettings( donationAccount, accountNumber, serviceType ) {
 
-    navigation.navigate('DonationAccountWebViewSettings', {
+    navigation.navigate( 'DonationAccountWebViewSettings', {
       account: donationAccount,
       accountNumber,
       serviceType,
-    })
+    } )
   }
 
   function performRefreshOnPullDown() {
-    dispatch(refreshAccountShell(accountShell, {
+    dispatch( refreshAccountShell( accountShell, {
       autoSync: false
-    }))
+    } ) )
   }
 
-  const showKnowMoreSheet = useCallback(() => {
+  const showKnowMoreSheet = useCallback( () => {
     presentBottomSheet(
       <KnowMoreBottomSheet
         accountKind={primarySubAccount.kind}
@@ -131,36 +131,36 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
       />,
       {
         ...defaultBottomSheetConfigs,
-        snapPoints: [0, '95%'],
+        snapPoints: [ 0, '95%' ],
         handleComponent: KnowMoreBottomSheetHandle,
       },
     )
-  }, [presentBottomSheet, dismissBottomSheet])
+  }, [ presentBottomSheet, dismissBottomSheet ] )
 
   const showReassignmentConfirmationBottomSheet = useCallback(
-    (destinationID) => {
+    ( destinationID ) => {
       presentBottomSheet(
         <TransactionReassignmentSuccessBottomSheet
           onViewAccountDetailsPressed={() => {
             dismissBottomSheet()
             navigation.dispatch(
-              resetStackToAccountDetails({
+              resetStackToAccountDetails( {
                 accountShellID: destinationID,
-              }),
+              } ),
             )
           }}
         />,
         {
           ...defaultBottomSheetConfigs,
-          snapPoints: [0, '40%'],
+          snapPoints: [ 0, '40%' ],
         },
       )
     },
-    [presentBottomSheet, dismissBottomSheet],
+    [ presentBottomSheet, dismissBottomSheet ],
   )
 
   const showMergeConfirmationBottomSheet = useCallback(
-    ({ source, destination }) => {
+    ( { source, destination } ) => {
       presentBottomSheet(
         <AccountShellMergeSuccessBottomSheet
           sourceAccountShell={source}
@@ -168,22 +168,22 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
           onViewAccountDetailsPressed={() => {
             dismissBottomSheet()
             navigation.dispatch(
-              resetStackToAccountDetails({
+              resetStackToAccountDetails( {
                 accountShellID: destination.id,
-              }),
+              } ),
             )
           }}
         />,
         {
           ...defaultBottomSheetConfigs,
-          snapPoints: [0, '67%'],
+          snapPoints: [ 0, '67%' ],
         },
       )
     },
-    [presentBottomSheet, dismissBottomSheet],
+    [ presentBottomSheet, dismissBottomSheet ],
   )
 
-  useTransactionReassignmentCompletedEffect({
+  useTransactionReassignmentCompletedEffect( {
     onSuccess: showReassignmentConfirmationBottomSheet,
     onError: () => {
       Alert.alert(
@@ -191,9 +191,9 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
         'An error occurred while attempting to reassign transactions'
       )
     },
-  })
+  } )
 
-  useAccountShellMergeCompletionEffect({
+  useAccountShellMergeCompletionEffect( {
     onSuccess: showMergeConfirmationBottomSheet,
     onError: () => {
       Alert.alert(
@@ -201,54 +201,54 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
         'An error occurred while attempting to merge accounts.'
       )
     },
-  })
+  } )
 
-  const showDonationWebViewSheet = useCallback(() => {
+  const showDonationWebViewSheet = useCallback( () => {
     const accountNumber = primarySubAccount.instanceNumber
     const serviceType = primarySubAccount.sourceKind
 
     let derivativeAccounts: DerivativeAccounts
 
-    if (serviceType === SourceAccountKind.REGULAR_ACCOUNT) {
-      derivativeAccounts = accountsState[serviceType].service.hdWallet.derivativeAccounts
-    } else if (serviceType === SourceAccountKind.SECURE_ACCOUNT) {
-      derivativeAccounts = accountsState[serviceType].service.secureHDWallet.derivativeAccounts
+    if ( serviceType === SourceAccountKind.REGULAR_ACCOUNT ) {
+      derivativeAccounts = accountsState[ serviceType ].service.hdWallet.derivativeAccounts
+    } else if ( serviceType === SourceAccountKind.SECURE_ACCOUNT ) {
+      derivativeAccounts = accountsState[ serviceType ].service.secureHDWallet.derivativeAccounts
     }
 
-    const donationAccount = derivativeAccounts[DONATION_ACCOUNT][accountNumber]
+    const donationAccount = derivativeAccounts[ DONATION_ACCOUNT ][ accountNumber ]
 
     presentBottomSheet(
       <DonationWebPageBottomSheet
         account={donationAccount}
         onClickSetting={() => {
           dismissBottomSheet()
-          navigateToDonationAccountWebViewSettings(donationAccount, accountNumber, serviceType)
+          navigateToDonationAccountWebViewSettings( donationAccount, accountNumber, serviceType )
         }}
       />,
       {
         ...defaultBottomSheetConfigs,
-        snapPoints: [0, '65%'],
+        snapPoints: [ 0, '65%' ],
       },
     )
-  }, [presentBottomSheet, dismissBottomSheet])
+  }, [ presentBottomSheet, dismissBottomSheet ] )
 
-  useEffect(() => {
-    dispatch(refreshAccountShell(accountShell, {
+  useEffect( () => {
+    dispatch( refreshAccountShell( accountShell, {
       autoSync: true
-    }))
-  }, [])
+    } ) )
+  }, [] )
 
 
-  useEffect(() => {
+  useEffect( () => {
     // missing fee & exchange rates patch(restore & upgrade)
     if (
       !averageTxFees ||
-      !Object.keys(averageTxFees).length ||
+      !Object.keys( averageTxFees ).length ||
       !exchangeRates ||
-      !Object.keys(exchangeRates).length
+      !Object.keys( exchangeRates ).length
     )
-      dispatch(fetchFeeAndExchangeRates());
-  }, []);
+      dispatch( fetchFeeAndExchangeRates() )
+  }, [] )
 
   return (
 
@@ -267,7 +267,6 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
           onKnowMorePressed={showKnowMoreSheet}
           onSettingsPressed={navigateToAccountSettings}
         />
-
 
         <View
           style={{
@@ -310,7 +309,7 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
           }}
         >
           <TransactionsList
-            transactions={accountTransactions.slice(0, 3)}
+            transactions={accountTransactions.slice( 0, 3 )}
             onTransactionSelected={handleTransactionSelection}
           />
         </View>
@@ -318,19 +317,19 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
         <View style={styles.footerSection}>
           <SendAndReceiveButtonsFooter
             onSendPressed={() => {
-              navigation.navigate('Send', {
+              navigation.navigate( 'Send', {
                 serviceType: primarySubAccount.sourceKind,
                 averageTxFees,
-                spendableBalance: AccountShell.getSpendableBalance(accountShell),
+                spendableBalance: AccountShell.getSpendableBalance( accountShell ),
                 derivativeAccountDetails,
                 accountShellID,
-              })
+              } )
             }}
             onReceivePressed={() => {
-              navigation.navigate('Receive', {
+              navigation.navigate( 'Receive', {
                 serviceType: primarySubAccount.sourceKind,
                 derivativeAccountDetails,
-              })
+              } )
             }}
             averageTxFees={averageTxFees}
             network={
@@ -346,7 +345,7 @@ const AccountDetailsContainerScreen: React.FC<Props> = ({ navigation }) => {
   )
 }
 
-const styles = StyleSheet.create({
+const styles = StyleSheet.create( {
   rootContainer: {
     paddingTop: 20,
   },
@@ -359,9 +358,9 @@ const styles = StyleSheet.create({
     paddingVertical: 38,
     marginBottom: 25
   },
-})
+} )
 
-AccountDetailsContainerScreen.navigationOptions = ({ navigation, }): NavigationScreenConfig<NavigationStackOptions, any> => {
+AccountDetailsContainerScreen.navigationOptions = ( { navigation, } ): NavigationScreenConfig<NavigationStackOptions, any> => {
   return {
     header() {
       const { accountShellID } = navigation.state.params

--- a/yarn.lock
+++ b/yarn.lock
@@ -6204,7 +6204,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4, lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1:
+lodash@^4, lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
Debounces the tap handling due to an issue where double-tapping triggered
multiple navigations and caused the App component to unmount -- leading to
the app crashing without much detail as to why.

(Further discussion can also be found in this thread: https://bithyve-workspace.slack.com/archives/CN7K6RY9Z/p1608213919048000)

Connected to https://github.com/bithyve/hexa/issues/2329.