### PR TITLE
2327 part 2 currency icons symbols

### DIFF
--- a/src/common/CommonFunctions/index.ts
+++ b/src/common/CommonFunctions/index.ts
@@ -51,7 +51,7 @@ export const getCurrencyImageByRegion = (
   currencyCode: string,
   type: 'light' | 'dark' | 'gray' | 'light_blue',
 ) => {
-  const dollarCurrency = [ 'USD', 'AUD', 'BBD', 'BSD', 'BZD', 'BMD', 'BND', 'KHR', 'CAD', 'KYD', 'XCD', 'FJD', 'GYD', 'HKD', 'JMD', 'LRD', 'NAD', 'NZD', 'SGD', 'SBD', 'SRD', 'TWD', 'TTD', 'TVD', 'ZWD', 'MXN', 'COP', 'CLP', 'UYU', 'DOP', 'ARS' ]
+  const dollarCurrency = [ 'USD', 'AUD', 'BBD', 'BSD', 'BZD', 'BMD', 'BND', 'KHR', 'CAD', 'KYD', 'XCD', 'FJD', 'GYD', 'HKD', 'JMD', 'LRD', 'NAD', 'NZD', 'SGD', 'SBD', 'SRD', 'TWD', 'USH', 'TTD', 'TVD', 'ZWD', 'MXN', 'COP', 'CLP', 'UYU', 'DOP', 'ARS' ]
   // These currencies also use the $ symbol although the currency is Peso 'MXN', 'COP', 'CLP', 'UYU', 'DOP', 'ARS'
 
   const poundCurrency = [ 'EGP', 'FKP', 'GIP', 'GGP', 'IMP', 'JEP', 'SHP', 'SYP', 'GBP' ]
@@ -133,4 +133,16 @@ export const getCurrencyImageByRegion = (
     }
     return require( '../../assets/images/currencySymbols/icon_chf_gray.png' )
   }
+
+  // Using the below as the default fall back in case some corrency is missed in the list
+  if ( type == 'light' ) {
+    return require( '../../assets/images/currencySymbols/icon_dollar_white.png' )
+  } else if ( type == 'dark' ) {
+    return require( '../../assets/images/currencySymbols/icon_dollar_dark.png' )
+  } else if ( type == 'gray' ) {
+    return require( '../../assets/images/currencySymbols/dollar_grey.png' )
+  } else if ( type == 'light_blue' ) {
+    return require( '../../assets/images/currencySymbols/icon_dollar_lightblue.png' )
+  }
+  return require( '../../assets/images/currencySymbols/icon_dollar_light.png' )
 }

--- a/src/components/CurrencyKindToggleSwitch.tsx
+++ b/src/components/CurrencyKindToggleSwitch.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { View, Image, TouchableOpacity, Text, ImageSourcePropType } from 'react-native';
-import { widthPercentageToDP as wp } from 'react-native-responsive-screen';
-import Colors from '../common/Colors';
-import { getCurrencyImageByRegion } from '../common/CommonFunctions/index';
-import { AppBottomSheetTouchableWrapper as TouchableWrapper } from './AppBottomSheetTouchableWrapper';
-import MaterialCurrencyCodeIcon, { materialIconCurrencyCodes } from './MaterialCurrencyCodeIcon';
+import React from 'react'
+import { View, Image, TouchableOpacity, Text, ImageSourcePropType } from 'react-native'
+import { widthPercentageToDP as wp } from 'react-native-responsive-screen'
+import Colors from '../common/Colors'
+import { getCurrencyImageByRegion } from '../common/CommonFunctions/index'
+import { AppBottomSheetTouchableWrapper as TouchableWrapper } from './AppBottomSheetTouchableWrapper'
+import MaterialCurrencyCodeIcon, { materialIconCurrencyCodes } from './MaterialCurrencyCodeIcon'
 
 
 export type Props = {
@@ -34,20 +34,20 @@ export type Props = {
 };
 
 
-const CurrencyCodeIcon = ({
+const CurrencyCodeIcon = ( {
   currencyCode,
   color,
-}) => {
+} ) => {
   return (
     <MaterialCurrencyCodeIcon
       currencyCode={currencyCode}
       color={color}
       size={12}
     />
-  );
-};
+  )
+}
 
-const CurrencyKindToggleSwitch: React.FC<Props> = ({
+const CurrencyKindToggleSwitch: React.FC<Props> = ( {
   isOn,
   fiatCurrencyCode,
   thumbColor,
@@ -62,8 +62,7 @@ const CurrencyKindToggleSwitch: React.FC<Props> = ({
   changeSettingToggle,
   disabled,
   onpress,
-}: Props) => {
-
+}: Props ) => {
   return (
     <TouchableWrapper
       activeOpacity={1}
@@ -72,27 +71,29 @@ const CurrencyKindToggleSwitch: React.FC<Props> = ({
       style={{
         flexDirection: isVertical ? 'column' : 'row',
         backgroundColor: trackColor || '#1E82C2',
-        height: isVertical ? wp('17%') : changeSettingToggle ? wp('8%') : wp('10%'),
-        width: isVertical ? wp('10%') : changeSettingToggle ? wp('14%') : wp('17%'),
-        borderRadius: wp('10%') / 2,
+        height: isVertical ? wp( '17%' ) : changeSettingToggle ? wp( '8%' ) : wp( '10%' ),
+        width: isVertical ? wp( '10%' ) : changeSettingToggle ? wp( '14%' ) : wp( '17%' ),
+        borderRadius: wp( '10%' ) / 2,
         alignItems: 'center',
         paddingLeft: isVertical ? 4 : 2,
         paddingRight: 2,
       }}
     >
       {isOn ? (
-        <View style={{ flexDirection: isVertical ? 'column' : 'row' }}>
+        <View style={{
+          flexDirection: isVertical ? 'column' : 'row' 
+        }}>
 
           <View
             style={{
-              height: thumbSize || wp('8%'),
-              width: thumbSize || wp('8%'),
+              height: thumbSize || wp( '8%' ),
+              width: thumbSize || wp( '8%' ),
               justifyContent: 'center',
               alignItems: 'center',
             }}
           >
             {inactiveOffImage || (
-              (!isNotImage && materialIconCurrencyCodes.includes(fiatCurrencyCode)) && (
+              ( !isNotImage && materialIconCurrencyCodes.includes( fiatCurrencyCode ) ) && (
                 <CurrencyCodeIcon
                   currencyCode={fiatCurrencyCode}
                   color={Colors.currencyGray}
@@ -101,23 +102,23 @@ const CurrencyKindToggleSwitch: React.FC<Props> = ({
               || (
                 <Image
                   source={
-                    inactiveOffImage || getCurrencyImageByRegion(fiatCurrencyCode, 'gray')
+                    inactiveOffImage || getCurrencyImageByRegion( fiatCurrencyCode, 'light' )
                   }
                   style={{
-                    width: wp('3.5%'),
-                    height: wp('3.5%'),
+                    width: wp( '3.5%' ),
+                    height: wp( '3.5%' ),
                     resizeMode: 'contain',
                   }}
                 />
-              ))}
+              ) )}
           </View>
 
           <View
             style={{
               backgroundColor: thumbColor || Colors.white,
-              height: thumbSize || wp('8%'),
-              width: thumbSize || wp('8%'),
-              borderRadius: thumbSize || wp('8%') / 2,
+              height: thumbSize || wp( '8%' ),
+              width: thumbSize || wp( '8%' ),
+              borderRadius: thumbSize || wp( '8%' ) / 2,
               marginLeft: isOn ? 'auto' : 0,
               justifyContent: 'center',
               alignItems: 'center',
@@ -127,11 +128,11 @@ const CurrencyKindToggleSwitch: React.FC<Props> = ({
             {!isNotImage && (
               <Image
                 source={
-                  activeOnImage || require('../assets/images/icons/icon_bitcoin_dark.png')
+                  activeOnImage || require( '../assets/images/icons/icon_bitcoin_dark.png' )
                 }
                 style={{
-                  width: wp('3.5%'),
-                  height: wp('3.5%'),
+                  width: wp( '3.5%' ),
+                  height: wp( '3.5%' ),
                   resizeMode: 'contain',
                 }}
               />
@@ -139,71 +140,73 @@ const CurrencyKindToggleSwitch: React.FC<Props> = ({
           </View>
         </View>
       ) : (
-          <View style={{ flexDirection: isVertical ? 'column' : 'row' }}>
-            <View
-              style={{
-                backgroundColor: thumbColor
-                  ? thumbColor
-                  : Colors.white,
-                height: thumbSize || wp('8%'),
-                width: thumbSize || wp('8%'),
-                borderRadius: thumbSize || wp('8%') / 2,
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginLeft: 2,
-                marginRight: isVertical ? 4 : 0,
-                marginTop: isVertical ? 4 : 0,
-              }}
-            >
-              {activeOffImage || (
-                (!isNotImage && materialIconCurrencyCodes.includes(fiatCurrencyCode)) && (
-                  <CurrencyCodeIcon
-                    currencyCode={fiatCurrencyCode}
-                    color={Colors.blue}
-                  />
-                )
+        <View style={{
+          flexDirection: isVertical ? 'column' : 'row' 
+        }}>
+          <View
+            style={{
+              backgroundColor: thumbColor
+                ? thumbColor
+                : Colors.white,
+              height: thumbSize || wp( '8%' ),
+              width: thumbSize || wp( '8%' ),
+              borderRadius: thumbSize || wp( '8%' ) / 2,
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginLeft: 2,
+              marginRight: isVertical ? 4 : 0,
+              marginTop: isVertical ? 4 : 0,
+            }}
+          >
+            {activeOffImage || (
+              ( !isNotImage && materialIconCurrencyCodes.includes( fiatCurrencyCode ) ) && (
+                <CurrencyCodeIcon
+                  currencyCode={fiatCurrencyCode}
+                  color={Colors.blue}
+                />
+              )
                 || (
                   <Image
                     source={
-                      activeOffImage || getCurrencyImageByRegion(fiatCurrencyCode, 'dark')
+                      activeOffImage || getCurrencyImageByRegion( fiatCurrencyCode, 'dark' )
                     }
                     style={{
-                      width: wp('3.5%'),
-                      height: wp('3.5%'),
+                      width: wp( '3.5%' ),
+                      height: wp( '3.5%' ),
                       resizeMode: 'contain',
                     }}
                   />
-                ))}
-            </View>
-
-            <View
-              style={{
-                height: thumbSize || wp('8%'),
-                width: thumbSize || wp('8%'),
-                justifyContent: 'center',
-                alignItems: 'center',
-                marginLeft: isOn ? 'auto' : isVertical ? 2 : 0,
-                marginRight: isVertical ? 2 : -3,
-                marginTop: isVertical ? 0 : 0,
-              }}
-            >
-              {!isNotImage && (
-                <Image
-                  source={
-                    inactiveOnImage || require('../assets/images/icons/icon_bitcoin_gray.png')
-                  }
-                  style={{
-                    width: wp('3.5%'),
-                    height: wp('3.5%'),
-                    resizeMode: 'contain',
-                  }}
-                />
-              )}
-            </View>
+                ) )}
           </View>
-        )}
+
+          <View
+            style={{
+              height: thumbSize || wp( '8%' ),
+              width: thumbSize || wp( '8%' ),
+              justifyContent: 'center',
+              alignItems: 'center',
+              marginLeft: isOn ? 'auto' : isVertical ? 2 : 0,
+              marginRight: isVertical ? 2 : -3,
+              marginTop: isVertical ? 0 : 0,
+            }}
+          >
+            {!isNotImage && (
+              <Image
+                source={
+                  inactiveOnImage || require( '../assets/images/icons/icon_bitcoin_gray.png' )
+                }
+                style={{
+                  width: wp( '3.5%' ),
+                  height: wp( '3.5%' ),
+                  resizeMode: 'contain',
+                }}
+              />
+            )}
+          </View>
+        </View>
+      )}
     </TouchableWrapper>
-  );
+  )
 }
 
-export default CurrencyKindToggleSwitch;
+export default CurrencyKindToggleSwitch

--- a/src/components/LabeledBalanceDisplay.tsx
+++ b/src/components/LabeledBalanceDisplay.tsx
@@ -1,26 +1,26 @@
-import React, { useMemo } from 'react';
+import React, { useMemo } from 'react'
 import {
   View,
   Text,
   StyleSheet,
   Image,
-} from 'react-native';
-import { RFValue } from 'react-native-responsive-fontsize';
-import Colors from '../common/Colors';
-import Fonts from '../common/Fonts';
-import CurrencyKind from '../common/data/enums/CurrencyKind';
-import useCurrencyCode from '../utils/hooks/state-selectors/UseCurrencyCode';
-import useCurrencyKind from '../utils/hooks/state-selectors/UseCurrencyKind';
+} from 'react-native'
+import { RFValue } from 'react-native-responsive-fontsize'
+import Colors from '../common/Colors'
+import Fonts from '../common/Fonts'
+import CurrencyKind from '../common/data/enums/CurrencyKind'
+import useCurrencyCode from '../utils/hooks/state-selectors/UseCurrencyCode'
+import useCurrencyKind from '../utils/hooks/state-selectors/UseCurrencyKind'
 import MaterialCurrencyCodeIcon, {
   materialIconCurrencyCodes,
-} from './MaterialCurrencyCodeIcon';
-import { getCurrencyImageByRegion } from '../common/CommonFunctions';
-import useFormattedAmountText from '../utils/hooks/formatting/UseFormattedAmountText';
-import useFormattedUnitText from '../utils/hooks/formatting/UseFormattedUnitText';
-import { Satoshis } from '../common/data/enums/UnitAliases';
-import BitcoinUnit, { displayNameForBitcoinUnit } from '../common/data/enums/BitcoinUnit';
-import { SATOSHIS_IN_BTC } from '../common/constants/Bitcoin';
-import { UsNumberFormat } from '../common/utilities';
+} from './MaterialCurrencyCodeIcon'
+import { getCurrencyImageByRegion } from '../common/CommonFunctions'
+import useFormattedAmountText from '../utils/hooks/formatting/UseFormattedAmountText'
+import useFormattedUnitText from '../utils/hooks/formatting/UseFormattedUnitText'
+import { Satoshis } from '../common/data/enums/UnitAliases'
+import BitcoinUnit, { displayNameForBitcoinUnit } from '../common/data/enums/BitcoinUnit'
+import { SATOSHIS_IN_BTC } from '../common/constants/Bitcoin'
+import { UsNumberFormat } from '../common/utilities'
 
 export type Props = {
   balance: Satoshis;
@@ -41,55 +41,61 @@ export type Props = {
  * and a unit label that dynamically changes with the user's
  * currency preferences.
  */
-const LabeledBalanceDisplay: React.FC<Props> = ({
+const LabeledBalanceDisplay: React.FC<Props> = ( {
   balance,
   bitcoinUnit = BitcoinUnit.SATS,
   currencyKind = useCurrencyKind(),
   iconSpacing = 4,
   textColor = Colors.currencyGray,
   bitcoinIconColor = 'gray',
-  containerStyle = {},
-  currencyImageStyle = {},
-  amountTextStyle = {},
-  unitTextStyle = {},
+  containerStyle = {
+  },
+  currencyImageStyle = {
+  },
+  amountTextStyle = {
+  },
+  unitTextStyle = {
+  },
   isTestAccount = false,
-}: Props) => {
-  const fiatCurrencyCode = useCurrencyCode();
+}: Props ) => {
+  const fiatCurrencyCode = useCurrencyCode()
 
-  const prefersBitcoin = useMemo(() => {
-    return currencyKind === CurrencyKind.BITCOIN;
-  }, [currencyKind]);
+  const prefersBitcoin = useMemo( () => {
+    return currencyKind === CurrencyKind.BITCOIN
+  }, [ currencyKind ] )
 
-  const amountToDisplay = useMemo(() => {
-    const divisor = [BitcoinUnit.SATS, BitcoinUnit.TSATS].includes(bitcoinUnit) ? 1 : SATOSHIS_IN_BTC;
+  const amountToDisplay = useMemo( () => {
+    const divisor = [ BitcoinUnit.SATS, BitcoinUnit.TSATS ].includes( bitcoinUnit ) ? 1 : SATOSHIS_IN_BTC
 
-    return balance / divisor;
-  }, [balance, bitcoinUnit]);
+    return balance / divisor
+  }, [ balance, bitcoinUnit ] )
 
   const formattedBalanceText = isTestAccount ?
-    UsNumberFormat(amountToDisplay)
-    : useFormattedAmountText(amountToDisplay);
+    UsNumberFormat( amountToDisplay )
+    : useFormattedAmountText( amountToDisplay )
 
   const formattedUnitText = isTestAccount ?
-    displayNameForBitcoinUnit(bitcoinUnit)
-    : useFormattedUnitText({ bitcoinUnit, currencyKind });
+    displayNameForBitcoinUnit( bitcoinUnit )
+    : useFormattedUnitText( {
+      bitcoinUnit, currencyKind 
+    } )
 
-  const bitcoinIconSource = useMemo(() => {
-    switch (bitcoinIconColor) {
-      case 'dark':
-        return require('../assets/images/currencySymbols/icon_bitcoin_dark.png');
-      case 'light':
-        return require('../assets/images/currencySymbols/icon_bitcoin_light.png');
-      case 'gray':
-        return require('../assets/images/currencySymbols/icon_bitcoin_gray.png');
-      default:
-        return require('../assets/images/currencySymbols/icon_bitcoin_gray.png');
+  const bitcoinIconSource = useMemo( () => {
+    switch ( bitcoinIconColor ) {
+        case 'dark':
+          return require( '../assets/images/currencySymbols/icon_bitcoin_dark.png' )
+        case 'light':
+          return require( '../assets/images/currencySymbols/icon_bitcoin_light.png' )
+        case 'gray':
+          return require( '../assets/images/currencySymbols/icon_bitcoin_gray.png' )
+        default:
+          return require( '../assets/images/currencySymbols/icon_bitcoin_gray.png' )
     }
-  }, [bitcoinIconColor]);
+  }, [ bitcoinIconColor ] )
 
-  const unitTextStyles = useMemo(() => {
-    const fontSize = Number(unitTextStyle.fontSize) || RFValue(11);
-    const paddingTop = fontSize * 0.5;
+  const unitTextStyles = useMemo( () => {
+    const fontSize = Number( unitTextStyle.fontSize ) || RFValue( 11 )
+    const paddingTop = fontSize * 0.5
 
     return {
       ...defaultStyles.unitText,
@@ -97,21 +103,21 @@ const LabeledBalanceDisplay: React.FC<Props> = ({
       ...unitTextStyle,
       fontSize,
       paddingTop,
-    };
-  }, [unitTextStyle]);
+    }
+  }, [ unitTextStyle ] )
 
   const BalanceCurrencyIcon = () => {
     const style = {
       ...defaultStyles.currencyImage,
       marginRight: iconSpacing,
       ...currencyImageStyle,
-    };
-
-    if (prefersBitcoin || isTestAccount) {
-      return <Image style={style} source={bitcoinIconSource} />;
     }
 
-    if (materialIconCurrencyCodes.includes(fiatCurrencyCode)) {
+    if ( prefersBitcoin || isTestAccount ) {
+      return <Image style={style} source={bitcoinIconSource} />
+    }
+
+    if ( materialIconCurrencyCodes.includes( fiatCurrencyCode ) ) {
       return (
         <MaterialCurrencyCodeIcon
           currencyCode={fiatCurrencyCode}
@@ -119,20 +125,24 @@ const LabeledBalanceDisplay: React.FC<Props> = ({
           size={style.width}
           style={style}
         />
-      );
+      )
     } else {
       return (
         <Image
           style={style}
-          source={getCurrencyImageByRegion(fiatCurrencyCode, bitcoinIconColor)}
+          source={getCurrencyImageByRegion( fiatCurrencyCode, bitcoinIconColor )}
         />
-      );
+      )
     }
-  };
+  }
 
   return (
-    <View style={{ ...defaultStyles.rootContainer, ...containerStyle }}>
-      <View style={{ marginRight: iconSpacing }}>
+    <View style={{
+      ...defaultStyles.rootContainer, ...containerStyle 
+    }}>
+      <View style={{
+        marginRight: iconSpacing 
+      }}>
         <BalanceCurrencyIcon />
       </View>
 
@@ -148,10 +158,10 @@ const LabeledBalanceDisplay: React.FC<Props> = ({
 
       <Text style={unitTextStyles}>{formattedUnitText}</Text>
     </View>
-  );
-};
+  )
+}
 
-const defaultStyles = StyleSheet.create({
+const defaultStyles = StyleSheet.create( {
   rootContainer: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -165,13 +175,14 @@ const defaultStyles = StyleSheet.create({
 
   amountText: {
     fontFamily: Fonts.OpenSans,
-    fontSize: RFValue(17),
+    fontSize: RFValue( 17 ),
     marginRight: 3,
   },
 
   unitText: {
     fontFamily: Fonts.FiraSansRegular,
   },
-});
+} )
 
-export default LabeledBalanceDisplay;
+export default LabeledBalanceDisplay
+                                                                                 

--- a/src/components/MaterialCurrencyCodeIcon.tsx
+++ b/src/components/MaterialCurrencyCodeIcon.tsx
@@ -18,7 +18,10 @@ export const materialIconCurrencyCodes = [
   'PHP',
   'EUR',
   'TWD',
-  'USD',
+  // All currencies that use a $ symbol
+  'USD', 'AUD', 'BBD', 'BSD', 'BZD', 'BMD', 'BND', 'KHR', 'CAD', 'KYD', 'XCD', 'FJD', 'GYD', 'HKD', 'JMD', 'LRD', 'NAD', 'NZD', 'SGD', 'SBD', 'SRD', 'TTD', 'TVD', 'ZWD', 'MXN', 'COP', 'CLP', 'UYU', 'DOP', 'ARS',
+  // All currencies that use a £ symbol
+  'EGP', 'FKP', 'GIP', 'GGP', 'IMP', 'JEP', 'SHP', 'SYP', 'GBP'
 ]
 
 
@@ -32,8 +35,6 @@ function getCurrencyCodeIconName( currencyCode: string ): string {
         return 'currency-cny'
       case 'JPY':
         return 'currency-jpy'
-      case 'GBP':
-        return 'currency-gbp'
       case 'KRW':
         return 'currency-krw'
       case 'RUB':
@@ -56,6 +57,49 @@ function getCurrencyCodeIconName( currencyCode: string ): string {
         return 'currency-php' 
       case 'EUR':
         return 'currency-eur'
+
+      // below are all the currencies which use a £ symbol
+      case 'EGP':
+      case 'FKP':
+      case 'GIP':
+      case 'GGP':
+      case 'IMP':
+      case 'JEP':
+      case 'SHP':
+      case 'SYP':
+      case 'GBP':
+        return 'currency-gbp'
+
+      // below are all the currencies which use a $ symbol
+      case 'AUD':
+      case 'BBD':
+      case 'BSD':
+      case 'BZD':
+      case 'BMD':
+      case 'BND':
+      case 'KHR':
+      case 'CAD':
+      case 'KYD':
+      case 'XCD':
+      case 'FJD':
+      case 'GYD':
+      case 'HKD':
+      case 'JMD':
+      case 'LRD':
+      case 'NAD':
+      case 'NZD':
+      case 'SGD':
+      case 'SBD':
+      case 'SRD':
+      case 'TTD':
+      case 'TVD':
+      case 'ZWD':
+      case 'MXN':
+      case 'COP':
+      case 'CLP':
+      case 'UYU':
+      case 'DOP':
+      case 'ARS':
       case 'USD':
         return 'currency-usd'
       default:

--- a/src/components/MaterialCurrencyCodeIcon.tsx
+++ b/src/components/MaterialCurrencyCodeIcon.tsx
@@ -13,10 +13,10 @@ export const materialIconCurrencyCodes = [
   'TRY',
   'INR',
   'ILS',
+  'MNT',
   'NGN',
   'PHP',
   'EUR',
-  'TRY',
   'TWD',
   'USD',
 ]
@@ -48,10 +48,12 @@ function getCurrencyCodeIconName( currencyCode: string ): string {
         return 'currency-ils'
       case 'KZT':
         return 'currency-kzt'
+      case 'MNT':
+        return 'currency-mnt'
       case 'NGN':
         return 'currency-ngn'
       case 'PHP':
-        return 'currency-php'
+        return 'currency-php' 
       case 'EUR':
         return 'currency-eur'
       case 'USD':

--- a/src/components/account-details/AccountDetailsNavHeader.tsx
+++ b/src/components/account-details/AccountDetailsNavHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { useDispatch } from 'react-redux'
-import { View, Text, StyleSheet, StatusBar, SafeAreaView, TouchableOpacity } from 'react-native'
+import { Image, View, Text, StyleSheet, StatusBar, SafeAreaView, TouchableOpacity } from 'react-native'
 import Colors from '../../common/Colors'
 import ScreenHeaderStyles from '../../common/Styles/ScreenHeaders'
 import FontAwesome from 'react-native-vector-icons/FontAwesome'
@@ -100,6 +100,7 @@ const AccountDetailsNavHeader: React.FC<Props> = ( {
 
           <View style={styles.currencyKindToggleContainer}>
             <CurrencyKindToggleSwitch
+              fiatCurrencyCode={currencyCode}
               activeOnImage={require( '../../assets/images/icons/icon_bitcoin_light.png' )}
               inactiveOnImage={require( '../../assets/images/icons/icon_bitcoin_dark.png' )}
               activeOffImage={
@@ -109,7 +110,7 @@ const AccountDetailsNavHeader: React.FC<Props> = ( {
                     color={Colors.white}
                     size={14}
                   />
-                  : getCurrencyImageByRegion( currencyCode, 'light' )
+                  : null
               }
               inactiveOffImage={
                 materialIconCurrencyCodes.includes( currencyCode ) ?
@@ -118,7 +119,7 @@ const AccountDetailsNavHeader: React.FC<Props> = ( {
                     color={Colors.blue}
                     size={14}
                   />
-                  : getCurrencyImageByRegion( currencyCode, 'dark' )
+                  : null
               }
               trackColor={Colors.lightBlue}
               thumbColor={Colors.blue}

--- a/src/pages/FastBitcoin/QuoteConfirmation.tsx
+++ b/src/pages/FastBitcoin/QuoteConfirmation.tsx
@@ -9,9 +9,10 @@ import {
 } from 'react-native-responsive-screen'
 import { AppBottomSheetTouchableWrapper } from '../../components/AppBottomSheetTouchableWrapper'
 import currencyIconSource from '../../utils/currency/currencyIconSource'
+import { getCurrencyImageByRegion } from '../../common/CommonFunctions'
 
 export default function QuoteConfirmation( props ) {
-  const currencySymbol = currencyIconSource( props.currencyCode, false )
+  const currencySymbol = getCurrencyImageByRegion( props.currencyCode, 'gray' )
   return (
     <View style={styles.modalContentContainer}>
       <View>


### PR DESCRIPTION
- Resolved bug fix for some currencies like SGD, PLN etc..
- Collated all $ and £ symbol currencies to use Material Icons
- Updated FBTC quotes page to use common utility for images and to show all currency symbols based on voucher currency

related to:
#2382 
#1969

